### PR TITLE
Fix jenkins shell

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -78,7 +78,7 @@ pipeline {
         }
         cleanup {
           sh "mkdir -p build-logs"
-          sh """
+          sh """#!/bin/bash
             while read -r LINE; do \
               docker logs \$(echo \$LINE | cut -d ' ' -f1) | gzip -6 > build-logs/\$(echo \$LINE | cut -d ' ' -f2).log.gz; \
             done < <(docker ps --filter "network=d3-${DOCKER_NETWORK}" --format "{{.ID}} {{.Names}}")


### PR DESCRIPTION
Signed-off-by: Bulat Saifullin <bulat@saifullin.ru>

change `sh` to `bash` in jenkins script