### PR TITLE
Fix for expansion tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext.kotlin_version = '1.3.10'
     ext.ktor_version = '1.0.0'
-    ext.notary_version='8d388c6e179e1f6d48f85eee89fa28b7583c7c53'
+    ext.notary_version='019f25c289d3e3fcf1e64de9064f962cd0c48936'
     repositories {
         mavenCentral()
         jcenter()

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext.kotlin_version = '1.3.10'
     ext.ktor_version = '1.0.0'
-    ext.notary_version='4d3b2e6089cdbbcf9f44b936b51f011e1355dc60'
+    ext.notary_version='d13b89c43dbc434731824e6ccd523ef956b757bb'
     repositories {
         mavenCentral()
         jcenter()

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext.kotlin_version = '1.3.10'
     ext.ktor_version = '1.0.0'
-    ext.notary_version='fae566d34e45f060c004a2f6e80902b3f8db7619'
+    ext.notary_version='4d3b2e6089cdbbcf9f44b936b51f011e1355dc60'
     repositories {
         mavenCentral()
         jcenter()

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext.kotlin_version = '1.3.10'
     ext.ktor_version = '1.0.0'
-    ext.notary_version='019f25c289d3e3fcf1e64de9064f962cd0c48936'
+    ext.notary_version='0.4.3-snapshot'
     repositories {
         mavenCentral()
         jcenter()

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext.kotlin_version = '1.3.10'
     ext.ktor_version = '1.0.0'
-    ext.notary_version='0.4.0-snapshot'
+    ext.notary_version='0.4.1-snapshot'
     repositories {
         mavenCentral()
         jcenter()

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext.kotlin_version = '1.3.10'
     ext.ktor_version = '1.0.0'
-    ext.notary_version='0.4.2-snapshot'
+    ext.notary_version='0.4.0-snapshot'
     repositories {
         mavenCentral()
         jcenter()

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext.kotlin_version = '1.3.10'
     ext.ktor_version = '1.0.0'
-    ext.notary_version='93bfe0560ef35f7aa33d47f879a931db8f653274'
+    ext.notary_version='8d388c6e179e1f6d48f85eee89fa28b7583c7c53'
     repositories {
         mavenCentral()
         jcenter()

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext.kotlin_version = '1.3.10'
     ext.ktor_version = '1.0.0'
-    ext.notary_version='0.4.1-snapshot'
+    ext.notary_version='fae566d34e45f060c004a2f6e80902b3f8db7619'
     repositories {
         mavenCentral()
         jcenter()

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext.kotlin_version = '1.3.10'
     ext.ktor_version = '1.0.0'
-    ext.notary_version='f013c058ce48e091ba619a79d04a51cbc2827508'
+    ext.notary_version='d13b89c43dbc434731824e6ccd523ef956b757bb'
     repositories {
         mavenCentral()
         jcenter()

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext.kotlin_version = '1.3.10'
     ext.ktor_version = '1.0.0'
-    ext.notary_version='0.4.1-snapshot'
+    ext.notary_version='0.4.2-snapshot'
     repositories {
         mavenCentral()
         jcenter()

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext.kotlin_version = '1.3.10'
     ext.ktor_version = '1.0.0'
-    ext.notary_version='d13b89c43dbc434731824e6ccd523ef956b757bb'
+    ext.notary_version='f013c058ce48e091ba619a79d04a51cbc2827508'
     repositories {
         mavenCentral()
         jcenter()

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext.kotlin_version = '1.3.10'
     ext.ktor_version = '1.0.0'
-    ext.notary_version='99d4c69753ebf410e79ee92b58973f93fc4c5042'
+    ext.notary_version='93bfe0560ef35f7aa33d47f879a931db8f653274'
     repositories {
         mavenCentral()
         jcenter()

--- a/eth-deposit/src/main/kotlin/com/d3/eth/deposit/EthDepositInitialization.kt
+++ b/eth-deposit/src/main/kotlin/com/d3/eth/deposit/EthDepositInitialization.kt
@@ -79,6 +79,16 @@ class EthDepositInitialization(
         ethDepositConfig
     )
 
+    init {
+        logger.info {
+            "Init deposit ethAddress=" +
+            WalletUtils.loadCredentials(
+                passwordsConfig.credentialsPassword,
+                ethDepositConfig.ethereum.credentialsPath
+            ).address
+        }
+    }
+
     /**
      * Init notary
      */

--- a/eth-deposit/src/main/kotlin/com/d3/eth/deposit/EthereumDepositExpansionStrategy.kt
+++ b/eth-deposit/src/main/kotlin/com/d3/eth/deposit/EthereumDepositExpansionStrategy.kt
@@ -14,6 +14,7 @@ import com.github.kittinunf.result.Result
 import iroha.protocol.BlockOuterClass
 import jp.co.soramitsu.iroha.java.IrohaAPI
 import jp.co.soramitsu.iroha.java.Transaction
+import mu.KLogging
 
 /**
  * Class responsible for ethereum expansion
@@ -23,6 +24,14 @@ class EthereumDepositExpansionStrategy(
     private val irohaAPI: IrohaAPI,
     private val ethDepositConfig: EthDepositConfig
 ) {
+
+    init {
+        logger.info {
+            "Init deposit expansion strategy, " +
+                    "expansionTriggerAccount=${ethDepositConfig.expansionTriggerAccount}, " +
+                    "expansionTriggerCreatorAccountId=${ethDepositConfig.expansionTriggerCreatorAccountId}"
+        }
+    }
 
     private val expansionService = ServiceExpansion(
         ethDepositConfig.expansionTriggerAccount,
@@ -76,4 +85,8 @@ class EthereumDepositExpansionStrategy(
         )
     }
 
+    /**
+     * Logger
+     */
+    companion object : KLogging()
 }

--- a/eth-withdrawal/src/main/kotlin/com/d3/eth/withdrawal/withdrawalservice/ProofCollector.kt
+++ b/eth-withdrawal/src/main/kotlin/com/d3/eth/withdrawal/withdrawalservice/ProofCollector.kt
@@ -148,7 +148,7 @@ class ProofCollector(
                 val ss = ArrayList<ByteArray>()
 
                 notaryPeerListProvider.getPeerList().forEach { peer ->
-                    WithdrawalServiceImpl.logger.info { "Query $peer for proof" }
+                    WithdrawalServiceImpl.logger.info { "Query $peer for proof for hash $hash" }
                     val res: khttp.responses.Response
                     try {
                         res = khttp.get("$peer/eth/$hash")

--- a/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/DepositIntegrationTest.kt
+++ b/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/DepositIntegrationTest.kt
@@ -37,10 +37,13 @@ class DepositIntegrationTest {
 
     private val registrationTestEnvironment = RegistrationServiceTestEnvironment(integrationHelper)
     private val ethRegistrationService: Job
+    private val ethDeposit: Job
 
     init {
         // run notary
-        integrationHelper.runEthDeposit()
+        ethDeposit = GlobalScope.launch {
+            integrationHelper.runEthDeposit()
+        }
         registrationTestEnvironment.registrationInitialization.init()
         ethRegistrationService = GlobalScope.launch {
             integrationHelper.runEthRegistrationService(integrationHelper.ethRegistrationConfig)
@@ -71,6 +74,7 @@ class DepositIntegrationTest {
     @AfterAll
     fun dropDown() {
         ethRegistrationService.cancel()
+        ethDeposit.cancel()
         integrationHelper.close()
     }
 

--- a/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/DepositIntegrationTest.kt
+++ b/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/DepositIntegrationTest.kt
@@ -98,6 +98,7 @@ class DepositIntegrationTest {
             integrationHelper.purgeAndwaitOneIrohaBlock {
                 integrationHelper.sendEth(amount, relayWallet)
             }
+            Thread.sleep(3_000)
 
             Assertions.assertEquals(
                 BigDecimal(amount, ETH_PRECISION).add(BigDecimal(initialAmount)),
@@ -141,7 +142,7 @@ class DepositIntegrationTest {
             integrationHelper.purgeAndwaitOneIrohaBlock {
                 integrationHelper.sendEth(amount, relayWallet)
             }
-
+            Thread.sleep(3_000)
 
             Assertions.assertEquals(
                 BigDecimal(amount, ETH_PRECISION).add(BigDecimal(initialAmount)),
@@ -177,6 +178,7 @@ class DepositIntegrationTest {
             integrationHelper.purgeAndwaitOneIrohaBlock {
                 integrationHelper.sendERC20Token(tokenAddress, amount, relayWallet)
             }
+            Thread.sleep(3_000)
 
             Assertions.assertEquals(
                 BigDecimal(amount, tokenInfo.precision).add(BigDecimal(initialAmount)),
@@ -216,6 +218,7 @@ class DepositIntegrationTest {
             integrationHelper.purgeAndwaitOneIrohaBlock {
                 integrationHelper.sendERC20Token(tokenAddress, amount, relayWallet)
             }
+            Thread.sleep(3_000)
 
             Assertions.assertEquals(
                 BigDecimal(amount, tokenInfo.precision).add(BigDecimal(initialAmount)),

--- a/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/DepositMultiIntegrationTest.kt
+++ b/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/DepositMultiIntegrationTest.kt
@@ -39,10 +39,14 @@ class DepositMultiIntegrationTest {
 
     private val registrationTestEnvironment = RegistrationServiceTestEnvironment(integrationHelper)
     private val ethRegistrationService: Job
+    private val ethDeposit1: Job
+    private val ethDeposit2: Job
 
     init {
         // run notary
-        integrationHelper.runEthDeposit()
+        ethDeposit1 = GlobalScope.launch {
+            integrationHelper.runEthDeposit()
+        }
         registrationTestEnvironment.registrationInitialization.init()
         ethRegistrationService = GlobalScope.launch {
             integrationHelper.runEthRegistrationService(integrationHelper.ethRegistrationConfig)
@@ -67,8 +71,9 @@ class DepositMultiIntegrationTest {
         integrationHelper.accountHelper.addNotarySignatory(keyPair2)
 
         // run 2nd instance of notary
-        integrationHelper.runEthDeposit(ethereumPasswords, depositConfig)
-
+        ethDeposit2 = GlobalScope.launch {
+            integrationHelper.runEthDeposit(ethereumPasswords, depositConfig)
+        }
     }
 
     /** Iroha client account */
@@ -95,6 +100,8 @@ class DepositMultiIntegrationTest {
 
     @AfterAll
     fun dropDown() {
+        ethDeposit1.cancel()
+        ethDeposit2.cancel()
         ethRegistrationService.cancel()
         integrationHelper.close()
     }

--- a/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/DepositMultiIntegrationTest.kt
+++ b/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/DepositMultiIntegrationTest.kt
@@ -146,7 +146,7 @@ class DepositMultiIntegrationTest {
             integrationHelper.purgeAndwaitOneIrohaBlock {
                 integrationHelper.sendEth(amount, relayWallet)
             }
-            runBlocking { delay(5_000) }
+            runBlocking { delay(10_000) }
 
             Assertions.assertEquals(
                 BigDecimal(amount, ETH_PRECISION).add(BigDecimal(initialAmount)),
@@ -182,7 +182,7 @@ class DepositMultiIntegrationTest {
             integrationHelper.purgeAndwaitOneIrohaBlock {
                 integrationHelper.sendERC20Token(tokenAddress, amount, relayWallet)
             }
-            runBlocking { delay(5_000) }
+            runBlocking { delay(10_000) }
 
             Assertions.assertEquals(
                 BigDecimal(amount, tokenInfo.precision).add(BigDecimal(initialAmount)),

--- a/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/DepositMultiIntegrationTest.kt
+++ b/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/DepositMultiIntegrationTest.kt
@@ -69,11 +69,16 @@ class DepositMultiIntegrationTest {
                 notaryCredential_ = irohaCredential
             )
 
+        // wait for deposit service
+        Thread.sleep(5_000)
         val notary2IrohaPublicKey = keyPair2.public.toHexString()
-        val notary2EthereumCredentials = DeployHelper(depositConfig.ethereum, ethereumPasswords).credentials
+        val notary2EthereumCredentials =
+            DeployHelper(depositConfig.ethereum, ethereumPasswords).credentials
         val notary2EthereumAddress = notary2EthereumCredentials.address
         val notary2Name = "notary_name_" + String.getRandomString(5)
         val notary2EndpointAddress = "http://127.0.0.1:${depositConfig.refund.port}"
+        // wait for expansion is finished
+        Thread.sleep(5_000)
 
         integrationHelper.triggerExpansion(
             integrationHelper.accountHelper.notaryAccount.accountId,
@@ -133,7 +138,8 @@ class DepositMultiIntegrationTest {
     fun depositMultisig() {
         Assertions.assertTimeoutPreemptively(timeoutDuration) {
             Thread.currentThread().name = this::class.simpleName
-            val initialAmount = integrationHelper.getIrohaAccountBalance(clientIrohaAccountId, etherAssetId)
+            val initialAmount =
+                integrationHelper.getIrohaAccountBalance(clientIrohaAccountId, etherAssetId)
             val amount = BigInteger.valueOf(1_234_000_000_000)
             // send ETH
             runBlocking { delay(2000) }
@@ -143,7 +149,12 @@ class DepositMultiIntegrationTest {
 
             Assertions.assertEquals(
                 BigDecimal(amount, ETH_PRECISION).add(BigDecimal(initialAmount)),
-                BigDecimal(integrationHelper.getIrohaAccountBalance(clientIrohaAccountId, etherAssetId))
+                BigDecimal(
+                    integrationHelper.getIrohaAccountBalance(
+                        clientIrohaAccountId,
+                        etherAssetId
+                    )
+                )
             )
         }
     }
@@ -162,7 +173,8 @@ class DepositMultiIntegrationTest {
             integrationHelper.nameCurrentThread(this::class.simpleName!!)
             val (tokenInfo, tokenAddress) = integrationHelper.deployRandomERC20Token(2)
             val assetId = "${tokenInfo.name}#ethereum"
-            val initialAmount = integrationHelper.getIrohaAccountBalance(clientIrohaAccountId, assetId)
+            val initialAmount =
+                integrationHelper.getIrohaAccountBalance(clientIrohaAccountId, assetId)
             val amount = BigInteger.valueOf(51)
 
             // send ETH

--- a/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/DepositMultiIntegrationTest.kt
+++ b/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/DepositMultiIntegrationTest.kt
@@ -146,6 +146,7 @@ class DepositMultiIntegrationTest {
             integrationHelper.purgeAndwaitOneIrohaBlock {
                 integrationHelper.sendEth(amount, relayWallet)
             }
+            runBlocking { delay(5_000) }
 
             Assertions.assertEquals(
                 BigDecimal(amount, ETH_PRECISION).add(BigDecimal(initialAmount)),
@@ -181,6 +182,7 @@ class DepositMultiIntegrationTest {
             integrationHelper.purgeAndwaitOneIrohaBlock {
                 integrationHelper.sendERC20Token(tokenAddress, amount, relayWallet)
             }
+            runBlocking { delay(5_000) }
 
             Assertions.assertEquals(
                 BigDecimal(amount, tokenInfo.precision).add(BigDecimal(initialAmount)),

--- a/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/DepositMultiIntegrationTest.kt
+++ b/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/DepositMultiIntegrationTest.kt
@@ -146,7 +146,7 @@ class DepositMultiIntegrationTest {
             integrationHelper.purgeAndwaitOneIrohaBlock {
                 integrationHelper.sendEth(amount, relayWallet)
             }
-            runBlocking { delay(10_000) }
+            runBlocking { delay(15_000) }
 
             Assertions.assertEquals(
                 BigDecimal(amount, ETH_PRECISION).add(BigDecimal(initialAmount)),
@@ -182,7 +182,7 @@ class DepositMultiIntegrationTest {
             integrationHelper.purgeAndwaitOneIrohaBlock {
                 integrationHelper.sendERC20Token(tokenAddress, amount, relayWallet)
             }
-            runBlocking { delay(10_000) }
+            runBlocking { delay(15_000) }
 
             Assertions.assertEquals(
                 BigDecimal(amount, tokenInfo.precision).add(BigDecimal(initialAmount)),

--- a/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/FailedTransactionTest.kt
+++ b/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/FailedTransactionTest.kt
@@ -35,9 +35,12 @@ class FailedTransactionTest {
 
     private val registrationTestEnvironment = RegistrationServiceTestEnvironment(integrationHelper)
     private val ethRegistrationService: Job
+    private val ethDeposit: Job
 
     init {
-        integrationHelper.runEthDeposit()
+        ethDeposit = GlobalScope.launch {
+            integrationHelper.runEthDeposit()
+        }
         registrationTestEnvironment.registrationInitialization.init()
         ethRegistrationService = GlobalScope.launch {
             integrationHelper.runEthRegistrationService(integrationHelper.ethRegistrationConfig)
@@ -46,6 +49,7 @@ class FailedTransactionTest {
 
     @AfterAll
     fun dropDown() {
+        ethDeposit.cancel()
         ethRegistrationService.cancel()
         integrationHelper.close()
     }

--- a/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/WithdrawalIntegrationTest.kt
+++ b/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/WithdrawalIntegrationTest.kt
@@ -51,9 +51,12 @@ class WithdrawalIntegrationTest {
 
     private val registrationTestEnvironment = RegistrationServiceTestEnvironment(integrationHelper)
     private val ethRegistrationService: Job
+    private val ethDeposit: Job
 
     init {
-        integrationHelper.runEthDeposit(ethDepositConfig = depositConfig)
+        ethDeposit = GlobalScope.launch {
+            integrationHelper.runEthDeposit(ethDepositConfig = depositConfig)
+        }
         registrationTestEnvironment.registrationInitialization.init()
         ethRegistrationService = GlobalScope.launch {
             integrationHelper.runEthRegistrationService(integrationHelper.ethRegistrationConfig)
@@ -68,6 +71,7 @@ class WithdrawalIntegrationTest {
 
     @AfterAll
     fun dropDown() {
+        ethDeposit.cancel()
         ethRegistrationService.cancel()
         integrationHelper.close()
     }
@@ -125,7 +129,7 @@ class WithdrawalIntegrationTest {
 
             // query
             res =
-                    khttp.get("http://127.0.0.1:${depositConfig.refund.port}/$ENDPOINT_ETHEREUM/$hash")
+                khttp.get("http://127.0.0.1:${depositConfig.refund.port}/$ENDPOINT_ETHEREUM/$hash")
 
             val moshi = Moshi
                 .Builder()

--- a/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/WithdrawalMultinotaryIntegrationTest.kt
+++ b/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/WithdrawalMultinotaryIntegrationTest.kt
@@ -60,6 +60,9 @@ class WithdrawalMultinotaryIntegrationTest {
 
     private val registrationTestEnvironment = RegistrationServiceTestEnvironment(integrationHelper)
     private val ethRegistrationService: Job
+    private val ethDeposit1: Job
+    private val ethDeposit2: Job
+
 
     init {
         val notaryConfig = loadLocalConfigs(
@@ -77,7 +80,9 @@ class WithdrawalMultinotaryIntegrationTest {
         // run 1st instance of deposit
         depositConfig1 =
                 integrationHelper.configHelper.createEthDepositConfig(ethereumConfig = ethereumConfig1)
-        integrationHelper.runEthDeposit(ethDepositConfig = depositConfig1)
+        ethDeposit1 = GlobalScope.launch {
+            integrationHelper.runEthDeposit(ethDepositConfig = depositConfig1)
+        }
 
         // create 2nd deposit config
         val ethereumConfig2 =
@@ -92,7 +97,9 @@ class WithdrawalMultinotaryIntegrationTest {
         )
 
         // run 2nd instance of deposit
-        integrationHelper.runEthDeposit(ethDepositConfig = depositConfig2)
+        ethDeposit2 = GlobalScope.launch {
+            integrationHelper.runEthDeposit(ethDepositConfig = depositConfig2)
+        }
 
         // run registration
         registrationTestEnvironment.registrationInitialization.init()
@@ -103,6 +110,8 @@ class WithdrawalMultinotaryIntegrationTest {
 
     @AfterAll
     fun dropDown() {
+        ethDeposit1.cancel()
+        ethDeposit2.cancel()
         ethRegistrationService.cancel()
         integrationHelper.close()
     }

--- a/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/WithdrawalPipelineIntegrationTest.kt
+++ b/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/WithdrawalPipelineIntegrationTest.kt
@@ -271,7 +271,7 @@ class WithdrawalPipelineIntegrationTest {
             toAddress,
             amount
         )
-        Thread.sleep(15_000)
+        Thread.sleep(10_000)
 
         // check balance of client in Iroha
         assertEquals(

--- a/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/WithdrawalPipelineIntegrationTest.kt
+++ b/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/WithdrawalPipelineIntegrationTest.kt
@@ -271,7 +271,7 @@ class WithdrawalPipelineIntegrationTest {
             toAddress,
             amount
         )
-        Thread.sleep(10_000)
+        Thread.sleep(15_000)
 
         // check balance of client in Iroha
         assertEquals(

--- a/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/WithdrawalPipelineIntegrationTest.kt
+++ b/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/WithdrawalPipelineIntegrationTest.kt
@@ -56,15 +56,17 @@ class WithdrawalPipelineIntegrationTest {
     private val timeoutDuration = Duration.ofMinutes(IrohaConfigHelper.timeoutMinutes)
 
     private val ethRegistrationService: Job
-
     private val withdrawalService: Job
+    private val ethDeposit: Job
 
     init {
         registrationTestEnvironment.registrationInitialization.init()
         ethRegistrationService = GlobalScope.launch {
             integrationHelper.runEthRegistrationService(ethRegistrationConfig)
         }
-        integrationHelper.runEthDeposit(ethDepositConfig = depositConfig)
+        ethDeposit = GlobalScope.launch {
+            integrationHelper.runEthDeposit(ethDepositConfig = depositConfig)
+        }
         withdrawalService = GlobalScope.launch {
             integrationHelper.runEthWithdrawalService()
         }
@@ -90,6 +92,7 @@ class WithdrawalPipelineIntegrationTest {
         registrationTestEnvironment.close()
         ethRegistrationService.cancel()
         withdrawalService.cancel()
+        ethDeposit.cancel()
         integrationHelper.close()
     }
 

--- a/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/WithdrawalRollbackIntegrationTest.kt
+++ b/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/WithdrawalRollbackIntegrationTest.kt
@@ -44,11 +44,13 @@ class WithdrawalRollbackIntegrationTest {
     private val notaryAccount = integrationHelper.accountHelper.notaryAccount.accountId
 
     private val ethRegistrationService: Job
-
     private val withdrawalService: Job
+    private val ethDeposit: Job
 
     init {
-        integrationHelper.runEthDeposit()
+        ethDeposit = GlobalScope.launch {
+            integrationHelper.runEthDeposit()
+        }
         registrationTestEnvironment.registrationInitialization.init()
         ethRegistrationService = GlobalScope.launch {
             integrationHelper.runEthRegistrationService(ethRegistrationConfig)
@@ -76,6 +78,7 @@ class WithdrawalRollbackIntegrationTest {
 
     @AfterAll
     fun dropDown() {
+        ethDeposit.cancel()
         registrationTestEnvironment.close()
         ethRegistrationService.cancel()
         withdrawalService.cancel()

--- a/notary-eth-integration-test/src/main/kotlin/integration/helper/EthIntegrationHelperUtil.kt
+++ b/notary-eth-integration-test/src/main/kotlin/integration/helper/EthIntegrationHelperUtil.kt
@@ -458,6 +458,11 @@ class EthIntegrationHelperUtil : IrohaIntegrationHelperUtil() {
         notaryName: String,
         notaryEndpointAddress: String
     ) {
+        logger.info {
+            "Send expansion transaction publicKey=${publicKey} " +
+                    "eth_address=${ethereumAddress}, " +
+                    "notary_endpoint=${notaryEndpointAddress}"
+        }
         val expansionDetails = ExpansionDetails(
             accountId,
             publicKey,


### PR DESCRIPTION
Add timeout since wait for one block is not reliable.
Updated notary dependency.
Run deposits in a coroutines.