### PR TITLE
Feature/client registration with wallet

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     ext.kotlin_version = '1.3.10'
     ext.ktor_version = '1.0.0'
     ext.notary_version = '3819fe46d00bfc09c0e32f2fe2afaf6e08c3f8fc'
-    ext.chain_adapter_client_version= 'd63c4af76aa589fbc545e1859122f66764771b64'
+    ext.chain_adapter_client_version= '9e65b4e38dd82d9a2ddc1065326050d4dc296075'
     ext.web3j_version = '4.2.0'
 
     repositories {

--- a/deploy/iroha/genesis.block
+++ b/deploy/iroha/genesis.block
@@ -92,7 +92,8 @@
                     "can_remove_signatory",
                     "can_grant_can_set_my_quorum",
                     "can_grant_can_add_my_signatory",
-                    "can_grant_can_remove_my_signatory"
+                    "can_grant_can_remove_my_signatory",
+                    "can_set_detail"
                   ]
                 }
               },
@@ -398,6 +399,20 @@
                 "appendRole": {
                   "accountId": "notary@notary",
                   "roleName": "notary"
+                }
+              },
+              {
+                "createAccount": {
+                  "accountName": "ethereum_wallets",
+                  "domainId": "notary",
+                  "publicKey": "0000000000000000000000000000000000000000000000000000000000000000"
+                }
+              },
+              {
+                "createAccount": {
+                  "accountName": "ethereum_relays",
+                  "domainId": "notary",
+                  "publicKey": "0000000000000000000000000000000000000000000000000000000000000000"
                 }
               },
               {

--- a/eth-deposit/src/main/kotlin/com/d3/eth/deposit/EthDepositConfig.kt
+++ b/eth-deposit/src/main/kotlin/com/d3/eth/deposit/EthDepositConfig.kt
@@ -17,9 +17,6 @@ interface RefundConfig {
 
 /** Configuration of deposit */
 interface EthDepositConfig {
-    /** Iroha account that has registered wallets */
-    val registrationServiceIrohaAccount: String
-
     /** Account that stores list of notaries endpoints */
     val notaryListStorageAccount: String
 
@@ -62,4 +59,16 @@ interface EthDepositConfig {
 
     /** Address of master smart contract in Ethereum */
     val ethMasterAddress: String
+
+    /** Ethereum wallet list storage account id */
+    val ethereumWalletStorageAccount: String
+
+    /** Ethereum wallet list setter account id */
+    val ethereumWalletSetterAccount: String
+
+    /** Ethereum relay list storage account id */
+    val ethereumRelayStorageAccount: String
+
+    /** Ethereum relay list setter account id */
+    val ethereumRelaySetterAccount: String
 }

--- a/eth-deposit/src/main/kotlin/com/d3/eth/deposit/EthDepositInitialization.kt
+++ b/eth-deposit/src/main/kotlin/com/d3/eth/deposit/EthDepositInitialization.kt
@@ -12,7 +12,6 @@ import com.d3.commons.notary.Notary
 import com.d3.commons.notary.NotaryImpl
 import com.d3.commons.notary.endpoint.ServerInitializationBundle
 import com.d3.commons.sidechain.SideChainEvent
-import com.d3.commons.sidechain.iroha.consumer.IrohaConsumerImpl
 import com.d3.commons.sidechain.iroha.consumer.MultiSigIrohaConsumer
 import com.d3.commons.sidechain.iroha.util.ModelUtil
 import com.d3.commons.sidechain.iroha.util.impl.IrohaQueryHelperImpl
@@ -26,7 +25,6 @@ import com.d3.eth.deposit.endpoint.EthRegistrationProofStrategyImpl
 import com.d3.eth.deposit.endpoint.RefundServerEndpoint
 import com.d3.eth.provider.EthAddressProvider
 import com.d3.eth.provider.EthTokensProvider
-import com.d3.eth.registration.EthRegistrationConfig
 import com.d3.eth.registration.wallet.EthereumWalletRegistrationHandler
 import com.d3.eth.sidechain.EthChainHandler
 import com.d3.eth.sidechain.EthChainListener
@@ -53,8 +51,10 @@ import java.math.BigInteger
 
 /**
  * Class for deposit instantiation
- * @param ethAddressProvider - provides with white list of ethereum wallets
+ * @param ethWalletProvider - provides with white list of ethereum wallets
+ * @param ethRelayProvider - provides with white list of ethereum relays
  * @param ethTokensProvider - provides with white list of ethereum ERC20 tokens
+ * @param registrationHandler - iroha-based wallet registration handler
  */
 class EthDepositInitialization(
     private val notaryCredential: IrohaCredential,

--- a/eth-deposit/src/main/kotlin/com/d3/eth/deposit/endpoint/EthAddPeerStrategy.kt
+++ b/eth-deposit/src/main/kotlin/com/d3/eth/deposit/endpoint/EthAddPeerStrategy.kt
@@ -7,6 +7,7 @@ package com.d3.eth.deposit.endpoint
 
 import com.d3.commons.expansion.ExpansionDetails
 import com.d3.commons.sidechain.iroha.util.IrohaQueryHelper
+import com.d3.commons.util.GsonInstance
 import com.d3.commons.util.irohaUnEscape
 import com.d3.eth.sidechain.util.hashToAddAndRemovePeer
 import com.d3.eth.sidechain.util.signUserData
@@ -28,7 +29,7 @@ class EthAddPeerStrategyImpl(
     private val expansionTriggerAccountId: String,
     private val expansionTriggerCreatorAccountId: String
 ) : EthAddPeerStrategy {
-    private val gson = Gson()
+    private val gson = GsonInstance.get()
 
     /**
      * Check and give proof

--- a/eth-deposit/src/main/kotlin/com/d3/eth/deposit/endpoint/EthRefundStrategyImpl.kt
+++ b/eth-deposit/src/main/kotlin/com/d3/eth/deposit/endpoint/EthRefundStrategyImpl.kt
@@ -12,7 +12,8 @@ import com.d3.commons.sidechain.iroha.util.impl.IrohaQueryHelperImpl
 import com.d3.commons.sidechain.iroha.util.isWithdrawalTransaction
 import com.d3.eth.deposit.EthDepositConfig
 import com.d3.eth.deposit.REFUND_OPERATION
-import com.d3.eth.provider.EthRelayProviderIrohaImpl
+import com.d3.eth.provider.ETH_RELAY
+import com.d3.eth.provider.EthAddressProviderIrohaImpl
 import com.d3.eth.provider.EthTokensProvider
 import com.d3.eth.sidechain.util.DeployHelper
 import com.d3.eth.sidechain.util.hashToWithdraw
@@ -39,10 +40,11 @@ class EthRefundStrategyImpl(
 ) : EthRefundStrategy {
     private val queryHelper =
         IrohaQueryHelperImpl(irohaAPI, credential.accountId, credential.keyPair)
-    private val relayProvider = EthRelayProviderIrohaImpl(
+    private val relayProvider = EthAddressProviderIrohaImpl(
         queryHelper,
-        credential.accountId,
-        depositConfig.registrationServiceIrohaAccount
+        depositConfig.ethereumRelayStorageAccount,
+        depositConfig.ethereumRelaySetterAccount,
+        ETH_RELAY
     )
 
     private val withdrawalAccountId = depositConfig.withdrawalAccountId
@@ -94,7 +96,7 @@ class EthRefundStrategyImpl(
                     val tokenInfo = tokensProvider.getTokenAddress(assetId)
                         .fanout { tokensProvider.getTokenPrecision(assetId) }
 
-                    relayProvider.getRelayByAccountId(withdrawalCommand.srcAccountId)
+                    relayProvider.getAddressByAccountId(withdrawalCommand.srcAccountId)
                         .fanout {
                             tokenInfo
                         }.fold(

--- a/eth-deposit/src/main/resources/deposit_local.properties
+++ b/eth-deposit/src/main/resources/deposit_local.properties
@@ -1,5 +1,4 @@
 # ========= Deposit =========
-eth-deposit.registrationServiceIrohaAccount=eth_registration_service@notary
 eth-deposit.notaryListStorageAccount=notaries@notary
 eth-deposit.ethAnchoredTokenStorageAccount=eth_anchored_token_service@notary
 eth-deposit.ethAnchoredTokenSetterAccount=eth_token_service@notary
@@ -8,6 +7,10 @@ eth-deposit.irohaAnchoredTokenSetterAccount=eth_token_service@notary
 eth-deposit.whitelistSetter=eth_registration_service@notary
 eth-deposit.expansionTriggerAccount=expansion_trigger@notary
 eth-deposit.expansionTriggerCreatorAccountId=superuser@bootstrap
+eth-deposit.ethereumWalletStorageAccount=ethereum_wallets@notary
+eth-deposit.ethereumWalletSetterAccount=notary@notary
+eth-deposit.ethereumRelayStorageAccount=ethereum_relays@notary
+eth-deposit.ethereumRelaySetterAccount=eth_registration_service@notary
 # Master smart contract address
 eth-deposit.ethMasterAddress=0xffc8470fd4a88754a97d645320c16e8a2d611a00
 # --------- Credentials -------

--- a/eth-deposit/src/main/resources/deposit_mainnet.properties
+++ b/eth-deposit/src/main/resources/deposit_mainnet.properties
@@ -1,5 +1,4 @@
 # ========= Deposit =========
-eth-deposit.registrationServiceIrohaAccount=eth_registration_service@notary
 eth-deposit.notaryListStorageAccount=notaries@notary
 eth-deposit.ethAnchoredTokenStorageAccount=eth_anchored_token_service@notary
 eth-deposit.ethAnchoredTokenSetterAccount=eth_token_service@notary
@@ -8,6 +7,10 @@ eth-deposit.irohaAnchoredTokenSetterAccount=eth_token_service@notary
 eth-deposit.whitelistSetter=eth_registration_service@notary
 eth-deposit.expansionTriggerAccount=expansion_trigger@notary
 eth-deposit.expansionTriggerCreatorAccountId=superuser@bootstrap
+eth-deposit.ethereumWalletStorageAccount=ethereum_wallets@notary
+eth-deposit.ethereumWalletSetterAccount=notary@notary
+eth-deposit.ethereumRelayStorageAccount=ethereum_relays@notary
+eth-deposit.ethereumRelaySetterAccount=eth_registration_service@notary
 # Address of implementation of Relay contract in Ethereum
 eth-deposit.ethMasterAddress=0x0000000000000000000000000000000000000000
 # --------- Credentials -------

--- a/eth-deposit/src/main/resources/deposit_testnet.properties
+++ b/eth-deposit/src/main/resources/deposit_testnet.properties
@@ -1,5 +1,4 @@
 # ========= Deposit =========
-eth-deposit.registrationServiceIrohaAccount=eth_registration_service@notary
 eth-deposit.notaryListStorageAccount=notaries@notary
 eth-deposit.ethAnchoredTokenStorageAccount=eth_anchored_token_service@notary
 eth-deposit.ethAnchoredTokenSetterAccount=eth_token_service@notary
@@ -8,6 +7,10 @@ eth-deposit.irohaAnchoredTokenSetterAccount=eth_token_service@notary
 eth-deposit.whitelistSetter=eth_registration_service@notary
 eth-deposit.expansionTriggerAccount=expansion_trigger@notary
 eth-deposit.expansionTriggerCreatorAccountId=superuser@bootstrap
+eth-deposit.ethereumWalletStorageAccount=ethereum_wallets@notary
+eth-deposit.ethereumWalletSetterAccount=notary@notary
+eth-deposit.ethereumRelayStorageAccount=ethereum_relays@notary
+eth-deposit.ethereumRelaySetterAccount=eth_registration_service@notary
 # Address of implementation of Relay contract in Ethereum
 eth-deposit.ethMasterAddress=0x0000000000000000000000000000000000000000
 # --------- Credentials -------

--- a/eth-deposit/src/test/kotlin/com/d3/eth/deposit/EthDepositConfigTest.kt
+++ b/eth-deposit/src/test/kotlin/com/d3/eth/deposit/EthDepositConfigTest.kt
@@ -123,7 +123,6 @@ class EthDepositConfigTest {
             "deposit.properties"
         ).get()
 
-        assertEquals(registrationServiceIrohaAccount, depositConfig.registrationServiceIrohaAccount)
         assertEquals(notaryListStorageAccount, depositConfig.notaryListStorageAccount)
         assertEquals(ethAnchoredTokenStorageAccount, depositConfig.ethAnchoredTokenStorageAccount)
         assertEquals(ethAnchoredTokenSetterAccount, depositConfig.ethAnchoredTokenSetterAccount)

--- a/eth-registration/build.gradle
+++ b/eth-registration/build.gradle
@@ -11,7 +11,6 @@ plugins {
 
 dependencies {
     implementation project(":eth")
-    implementation project(":eth-registration")
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
     implementation "com.github.d3ledger.notary:notary-commons:$notary_version"

--- a/eth-registration/build.gradle
+++ b/eth-registration/build.gradle
@@ -11,9 +11,12 @@ plugins {
 
 dependencies {
     implementation project(":eth")
+    implementation project(":eth-registration")
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
     implementation "com.github.d3ledger.notary:notary-commons:$notary_version"
+
+    implementation "org.web3j:core:$web3j_version"
 }
 
 apply plugin: 'application'

--- a/eth-registration/src/main/kotlin/com/d3/eth/registration/EthRegistrationConfig.kt
+++ b/eth-registration/src/main/kotlin/com/d3/eth/registration/EthRegistrationConfig.kt
@@ -19,7 +19,7 @@ interface EthRegistrationConfig {
     val relayRegistrationIrohaAccount: String
 
     /** Iroha account of relay account register */
-    val notaryIrohaAccount: String
+    val relayStorageAccount: String
 
     val registrationCredential: IrohaCredentialRawConfig
 

--- a/eth-registration/src/main/kotlin/com/d3/eth/registration/EthRegistrationServiceInitialization.kt
+++ b/eth-registration/src/main/kotlin/com/d3/eth/registration/EthRegistrationServiceInitialization.kt
@@ -9,8 +9,9 @@ import com.d3.commons.model.IrohaCredential
 import com.d3.commons.registration.RegistrationServiceEndpoint
 import com.d3.commons.sidechain.iroha.consumer.IrohaConsumerImpl
 import com.d3.commons.sidechain.iroha.util.impl.IrohaQueryHelperImpl
+import com.d3.eth.provider.ETH_RELAY
 import com.d3.eth.provider.EthFreeRelayProvider
-import com.d3.eth.provider.EthRelayProviderIrohaImpl
+import com.d3.eth.provider.EthAddressProviderIrohaImpl
 import com.github.kittinunf.result.Result
 import com.github.kittinunf.result.map
 import jp.co.soramitsu.iroha.java.IrohaAPI
@@ -55,10 +56,11 @@ class EthRegistrationServiceInitialization(
                         ethRegistrationConfig.notaryIrohaAccount,
                         ethRegistrationConfig.relayRegistrationIrohaAccount
                     ),
-                    EthRelayProviderIrohaImpl(
+                    EthAddressProviderIrohaImpl(
                         queryHelper,
                         ethRegistrationConfig.notaryIrohaAccount,
-                        ethRegistrationConfig.relayRegistrationIrohaAccount
+                        ethRegistrationConfig.relayRegistrationIrohaAccount,
+                        ETH_RELAY
                     )
                 ),
                 IrohaConsumerImpl(credential, irohaAPI)

--- a/eth-registration/src/main/kotlin/com/d3/eth/registration/EthRegistrationServiceInitialization.kt
+++ b/eth-registration/src/main/kotlin/com/d3/eth/registration/EthRegistrationServiceInitialization.kt
@@ -53,12 +53,12 @@ class EthRegistrationServiceInitialization(
                 Pair(
                     EthFreeRelayProvider(
                         queryHelper,
-                        ethRegistrationConfig.notaryIrohaAccount,
+                        ethRegistrationConfig.relayStorageAccount,
                         ethRegistrationConfig.relayRegistrationIrohaAccount
                     ),
                     EthAddressProviderIrohaImpl(
                         queryHelper,
-                        ethRegistrationConfig.notaryIrohaAccount,
+                        ethRegistrationConfig.relayStorageAccount,
                         ethRegistrationConfig.relayRegistrationIrohaAccount,
                         ETH_RELAY
                     )
@@ -71,7 +71,7 @@ class EthRegistrationServiceInitialization(
                 ethFreeRelayProvider,
                 ethRelayProvider,
                 irohaConsumer,
-                ethRegistrationConfig.notaryIrohaAccount
+                ethRegistrationConfig.relayStorageAccount
             )
         }.map { registrationStrategy ->
             RegistrationServiceEndpoint(

--- a/eth-registration/src/main/kotlin/com/d3/eth/registration/EthRegistrationStrategyImpl.kt
+++ b/eth-registration/src/main/kotlin/com/d3/eth/registration/EthRegistrationStrategyImpl.kt
@@ -9,9 +9,9 @@ import com.d3.commons.model.D3ErrorException
 import com.d3.commons.registration.RegistrationStrategy
 import com.d3.commons.registration.SideChainRegistrator
 import com.d3.commons.sidechain.iroha.consumer.IrohaConsumer
-import com.d3.eth.provider.ETH_WALLET
+import com.d3.eth.provider.ETH_RELAY
 import com.d3.eth.provider.EthFreeRelayProvider
-import com.d3.eth.provider.EthRelayProvider
+import com.d3.eth.provider.EthAddressProvider
 import com.github.kittinunf.result.Result
 import com.github.kittinunf.result.flatMap
 import mu.KLogging
@@ -21,7 +21,7 @@ import mu.KLogging
  */
 class EthRegistrationStrategyImpl(
     private val ethFreeRelayProvider: EthFreeRelayProvider,
-    private val ethRelayProvider: EthRelayProvider,
+    private val ethAddressProvider: EthAddressProvider,
     private val irohaConsumer: IrohaConsumer,
     private val notaryIrohaAccount: String
 ) : RegistrationStrategy {
@@ -34,7 +34,7 @@ class EthRegistrationStrategyImpl(
         SideChainRegistrator(
             irohaConsumer,
             notaryIrohaAccount,
-            ETH_WALLET
+            ETH_RELAY
         )
 
     /**
@@ -51,7 +51,7 @@ class EthRegistrationStrategyImpl(
         publicKey: String
     ): Result<String, Exception> {
         // check that client hasn't been registered yet
-        return ethRelayProvider.getRelayByAccountId("$accountName@$domainId")
+        return ethAddressProvider.getAddressByAccountId("$accountName@$domainId")
             .flatMap { assignedRelays ->
                 if (assignedRelays.isPresent)
                     throw D3ErrorException.warning(

--- a/eth-registration/src/main/kotlin/com/d3/eth/registration/EthRegistrationStrategyImpl.kt
+++ b/eth-registration/src/main/kotlin/com/d3/eth/registration/EthRegistrationStrategyImpl.kt
@@ -10,8 +10,8 @@ import com.d3.commons.registration.RegistrationStrategy
 import com.d3.commons.registration.SideChainRegistrator
 import com.d3.commons.sidechain.iroha.consumer.IrohaConsumer
 import com.d3.eth.provider.ETH_RELAY
-import com.d3.eth.provider.EthFreeRelayProvider
 import com.d3.eth.provider.EthAddressProvider
+import com.d3.eth.provider.EthFreeRelayProvider
 import com.github.kittinunf.result.Result
 import com.github.kittinunf.result.flatMap
 import mu.KLogging
@@ -23,19 +23,18 @@ class EthRegistrationStrategyImpl(
     private val ethFreeRelayProvider: EthFreeRelayProvider,
     private val ethAddressProvider: EthAddressProvider,
     private val irohaConsumer: IrohaConsumer,
-    private val notaryIrohaAccount: String
+    relayStorageAccount: String
 ) : RegistrationStrategy {
 
     init {
-        logger.info { "Init EthRegistrationStrategyImpl with irohaCreator=${irohaConsumer.creator}, notaryIrohaAccount=$notaryIrohaAccount" }
+        logger.info { "Init EthRegistrationStrategyImpl with irohaCreator=${irohaConsumer.creator}, relayStorageAccount=$relayStorageAccount" }
     }
 
-    private val ethereumAccountRegistrator =
-        SideChainRegistrator(
-            irohaConsumer,
-            notaryIrohaAccount,
-            ETH_RELAY
-        )
+    private val ethereumAccountRegistrator = SideChainRegistrator(
+        irohaConsumer,
+        relayStorageAccount,
+        ETH_RELAY
+    )
 
     /**
      * Register new notary client

--- a/eth-registration/src/main/kotlin/com/d3/eth/registration/wallet/EthereumRegistrationHelper.kt
+++ b/eth-registration/src/main/kotlin/com/d3/eth/registration/wallet/EthereumRegistrationHelper.kt
@@ -30,6 +30,8 @@ fun checkRegistrationProof(proof: EthereumRegistrationProof): Boolean {
     val address = Keys.getAddress(proof.publicKey)
 
     // Iterate recId [0..3] while the correct way not found
+    // there are 4 potential outputs including null values, thus we should check output
+    // comparing to expecting public key
     for (i in 0..3) {
         // null is a valid result, skip it
         val res =

--- a/eth-registration/src/main/kotlin/com/d3/eth/registration/wallet/EthereumRegistrationHelper.kt
+++ b/eth-registration/src/main/kotlin/com/d3/eth/registration/wallet/EthereumRegistrationHelper.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright D3 Ledger, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.d3.eth.registration.wallet
+
+import org.web3j.crypto.ECKeyPair
+import org.web3j.crypto.Hash
+import org.web3j.crypto.Keys
+import org.web3j.crypto.Sign
+
+/**
+ * Create signature proof by signing hash of address generated from public key.
+ * @param ecKeyPair EC keypair
+ * @return proof singed by EC keypair
+ */
+fun createRegistrationProof(ecKeyPair: ECKeyPair): EthereumRegistrationProof {
+    val address = Keys.getAddress(ecKeyPair.publicKey)
+    val esig = ecKeyPair.sign(Hash.sha3(address.toByteArray()))
+    return EthereumRegistrationProof(esig, ecKeyPair.publicKey)
+}
+
+/**
+ * Check proof is actually signature of hash of address get from public key.
+ * @param proof signature and public key
+ * @return true if signature is correct, false otherwise
+ */
+fun checkRegistrationProof(proof: EthereumRegistrationProof): Boolean {
+    val address = Keys.getAddress(proof.publicKey)
+
+    // Iterate recId [0..3] while the correct way not found
+    for (i in 0..3) {
+        // null is a valid result, skip it
+        val res =
+            Sign.recoverFromSignature(i, proof.signature, Hash.sha3(address.toByteArray()))
+                ?: continue
+        if (Keys.getAddress(res) == address)
+            return true
+    }
+    return false
+}

--- a/eth-registration/src/main/kotlin/com/d3/eth/registration/wallet/EthereumRegistrationProof.kt
+++ b/eth-registration/src/main/kotlin/com/d3/eth/registration/wallet/EthereumRegistrationProof.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright D3 Ledger, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.d3.eth.registration.wallet
+
+import com.google.gson.Gson
+import org.web3j.crypto.*
+import java.math.BigInteger
+
+const val ETH_REGISTRATION_KEY = "register_wallet"
+
+/**
+ * Proof that Ethereum account belongs to the owner of the private key.
+ * EC Signature of an address generated from public key.
+ */
+data class EthereumRegistrationProof(
+    val signature: ECDSASignature,
+    val publicKey: BigInteger
+) {
+    /**
+     * Ethereum address derived from a public key
+     */
+    fun getAddress(): String = Keys.getAddress(publicKey)
+
+    /**
+     * Serialize this to json
+     */
+    fun toJson(): String = Gson().toJson(this)
+}

--- a/eth-registration/src/main/kotlin/com/d3/eth/registration/wallet/EthereumWalletRegistrationHandler.kt
+++ b/eth-registration/src/main/kotlin/com/d3/eth/registration/wallet/EthereumWalletRegistrationHandler.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright D3 Ledger, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.d3.eth.registration.wallet
+
+import com.d3.commons.registration.SideChainRegistrator
+import com.d3.commons.sidechain.iroha.consumer.IrohaConsumer
+import com.d3.commons.util.hex
+import com.d3.commons.util.irohaUnEscape
+import com.d3.eth.provider.ETH_WALLET
+import com.d3.eth.provider.EthAddressProvider
+import com.d3.eth.registration.wallet.ETH_REGISTRATION_KEY
+import com.d3.eth.registration.wallet.EthereumRegistrationProof
+import com.google.gson.Gson
+import iroha.protocol.BlockOuterClass
+import jp.co.soramitsu.iroha.java.Transaction
+import jp.co.soramitsu.iroha.java.Utils
+import mu.KLogging
+
+const val ETH_FAILED_REGISTRATION_KEY = "failed_registration"
+
+/**
+ * Handles ethereum wallet registration events from Iroha blocks
+ */
+class EthereumWalletRegistrationHandler(
+    val irohaConsumer: IrohaConsumer,
+    val registrationTriggerAccountId: String,
+    walletStorageIrohaAccountId: String,
+    private val ethWalletProvider: EthAddressProvider,
+    private val ethRelayProvider: EthAddressProvider
+) {
+    val gson = Gson()
+
+    val registrator = SideChainRegistrator(
+        irohaConsumer,
+        walletStorageIrohaAccountId,
+        ETH_WALLET
+    )
+
+    fun filterAndRegister(block: BlockOuterClass.Block) {
+        block.blockV1.payload.transactionsList
+            // Get commands
+            .flatMap { tx ->
+                val txHash = String.hex(Utils.hash(tx))
+                val clientId = tx.payload.reducedPayload.creatorAccountId
+                tx.payload.reducedPayload.commandsList
+                    .filter { command -> command.hasSetAccountDetail() }
+                    .map { command -> command.setAccountDetail }
+                    // Get registration trigger
+                    .filter { setAccountDetail ->
+                        setAccountDetail.accountId == registrationTriggerAccountId &&
+                                setAccountDetail.key == ETH_REGISTRATION_KEY
+                    }
+                    .map { setAccountDetail ->
+                        try {
+                            val registrationProof = gson.fromJson(
+                                setAccountDetail.value.irohaUnEscape(),
+                                EthereumRegistrationProof::class.java
+                            )
+                            val ethAddress = "0x${registrationProof.getAddress()}"
+
+                            // check address is not used
+                            if (ethWalletProvider.getAddresses().get().containsKey(ethAddress))
+                                throw IllegalArgumentException("Address $ethAddress already registered as wallet")
+                            if (ethRelayProvider.getAddresses().get().containsKey(ethAddress))
+                                throw IllegalArgumentException("Address $ethAddress already registered as relay")
+
+                            // ensure wallet is signed with correct private key
+                            if (checkRegistrationProof(registrationProof)) {
+                                val registrationTxHash = registrator.register(
+                                    ethAddress,
+                                    clientId
+                                ) { clientId }.get()
+                                logger.info { "Registration with Ethereum wallet $ethAddress triggered for $clientId completed with tx $registrationTxHash" }
+
+                            } else {
+                                throw IllegalArgumentException("Registration triggered with wrong proof for ${setAccountDetail.accountId} with wallet $ethAddress")
+                            }
+                        } catch (ex: Exception) {
+                            logger.error(
+                                "Ethereum registration for client $clientId failed",
+                                ex
+                            )
+                            saveFailedRegistration(clientId, txHash, ex.message!!)
+                        }
+                    }
+            }
+    }
+
+    private fun saveFailedRegistration(accountId: String, hash: String, reason: String) {
+        val tx = Transaction.builder(irohaConsumer.creator)
+            .setAccountDetail(
+                accountId,
+                ETH_FAILED_REGISTRATION_KEY,
+                "registration $hash, reason $reason"
+            )
+            .setQuorum(irohaConsumer.getConsumerQuorum().get())
+            .build()
+        irohaConsumer.send(tx).get()
+    }
+
+    /**
+     * Logger
+     */
+    companion object : KLogging()
+}

--- a/eth-registration/src/main/kotlin/com/d3/eth/registration/wallet/EthereumWalletRegistrationHandler.kt
+++ b/eth-registration/src/main/kotlin/com/d3/eth/registration/wallet/EthereumWalletRegistrationHandler.kt
@@ -7,6 +7,7 @@ package com.d3.eth.registration.wallet
 
 import com.d3.commons.registration.SideChainRegistrator
 import com.d3.commons.sidechain.iroha.consumer.IrohaConsumer
+import com.d3.commons.util.GsonInstance
 import com.d3.commons.util.hex
 import com.d3.commons.util.irohaUnEscape
 import com.d3.eth.provider.ETH_WALLET
@@ -31,9 +32,9 @@ class EthereumWalletRegistrationHandler(
     private val ethWalletProvider: EthAddressProvider,
     private val ethRelayProvider: EthAddressProvider
 ) {
-    val gson = Gson()
+    private val gson = GsonInstance.get()
 
-    val registrator = SideChainRegistrator(
+    private val registrator = SideChainRegistrator(
         irohaConsumer,
         walletStorageIrohaAccountId,
         ETH_WALLET

--- a/eth-registration/src/main/resources/registration_local.properties
+++ b/eth-registration/src/main/resources/registration_local.properties
@@ -4,7 +4,7 @@ eth-registration.port=8083
 # Account of relay registration service
 eth-registration.relayRegistrationIrohaAccount=eth_registration_service@notary
 # Account to store registered free wallets
-eth-registration.notaryIrohaAccount=notary@notary
+eth-registration.relayStorageAccount=ethereum_relays@notary
 # --------- Credentials -----------
 eth-registration.registrationCredential.accountId=eth_registration_service@notary
 eth-registration.registrationCredential.pubkey=fe268bdac7b3c0cac9471e915299b481991c9b0b14543f65868c561dafd6b689

--- a/eth-registration/src/main/resources/registration_mainnet.properties
+++ b/eth-registration/src/main/resources/registration_mainnet.properties
@@ -4,7 +4,7 @@ eth-registration.port=8083
 # Account of relay registration service
 eth-registration.relayRegistrationIrohaAccount=eth_registration_service@notary
 # Account to store registered free wallets
-eth-registration.notaryIrohaAccount=notary@notary
+eth-registration.relayStorageAccount=ethereum_relays@notary
 # --------- Credentials -----------
 eth-registration.registrationCredential.accountId=eth_registration_service@notary
 eth-registration.registrationCredential.pubkey=fe268bdac7b3c0cac9471e915299b481991c9b0b14543f65868c561dafd6b689

--- a/eth-registration/src/main/resources/registration_testnet.properties
+++ b/eth-registration/src/main/resources/registration_testnet.properties
@@ -4,7 +4,7 @@ eth-registration.port=8083
 # Account of relay registration service
 eth-registration.relayRegistrationIrohaAccount=eth_registration_service@notary
 # Account to store registered free wallets
-eth-registration.notaryIrohaAccount=notary@notary
+eth-registration.relayStorageAccount=ethereum_relays@notary
 # --------- Credentials -----------
 eth-registration.registrationCredential.accountId=eth_registration_service@notary
 eth-registration.registrationCredential.pubkey=fe268bdac7b3c0cac9471e915299b481991c9b0b14543f65868c561dafd6b689

--- a/eth-registration/src/test/kotlin/com/d3/eth/registration/EthRegistrationConfigTest.kt
+++ b/eth-registration/src/test/kotlin/com/d3/eth/registration/EthRegistrationConfigTest.kt
@@ -31,8 +31,8 @@ class EthRegistrationConfigTest {
             "ETH-REGISTRATION_RELAYREGISTRATIONIROHAACCOUNT",
             relayRegistrationIrohaAccount
         )
-        val notaryIrohaAccount = "notary@account"
-        environmentVariables.set("ETH-REGISTRATION_NOTARYIROHAACCOUNT", notaryIrohaAccount)
+        val relayStorageAccount = "notary@account"
+        environmentVariables.set("ETH-REGISTRATION_RELAYSTORAGEACCOUNT", relayStorageAccount)
         val registrationCredentialAccountId = "registration@credential"
         environmentVariables.set("ETH-REGISTRATION_REGISTRATIONCREDENTIAL_ACCOUNTID", registrationCredentialAccountId)
         val registrationCredentialPubkey = "pubkey..."
@@ -54,7 +54,7 @@ class EthRegistrationConfigTest {
 
         assertEquals(port.toInt(), registrationConfig.port)
         assertEquals(relayRegistrationIrohaAccount, registrationConfig.relayRegistrationIrohaAccount)
-        assertEquals(notaryIrohaAccount, registrationConfig.notaryIrohaAccount)
+        assertEquals(relayStorageAccount, registrationConfig.relayStorageAccount)
         assertEquals(registrationCredentialAccountId, registrationConfig.registrationCredential.accountId)
         assertEquals(registrationCredentialPubkey, registrationConfig.registrationCredential.pubkey)
         assertEquals(registrationCredentialPrivkey, registrationConfig.registrationCredential.privkey)

--- a/eth-registration/src/test/kotlin/com/d3/eth/registration/wallet/EthereumRegistrationHelperTest.kt
+++ b/eth-registration/src/test/kotlin/com/d3/eth/registration/wallet/EthereumRegistrationHelperTest.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright D3 Ledger, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.d3.eth.registration.wallet
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.web3j.crypto.ECDSASignature
+import org.web3j.crypto.Hash
+import org.web3j.crypto.Keys
+import java.math.BigInteger
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class EthereumRegistrationHelperTest {
+
+    /**
+     * @given proof formed from keypair
+     * @when get address from proof
+     * @then address is equal to address generated from public key
+     */
+    @Test
+    fun testGetAddress() {
+        val keypair = Keys.createEcKeyPair()
+        val proof = createRegistrationProof(keypair)
+
+        assertEquals(Keys.getAddress(keypair.publicKey), proof.getAddress())
+    }
+
+    /**
+     * @given EC keypair
+     * @when signature is generated
+     * @then check returns true
+     */
+    @Test
+    fun testCorrect() {
+        val keypair = Keys.createEcKeyPair()
+        val proof = createRegistrationProof(keypair)
+
+        assertTrue { checkRegistrationProof(proof) }
+    }
+
+    /**
+     * @given EC keypair and signature generated with wrong address
+     * @when check signature
+     * @then check returns false
+     */
+    @Test
+    fun testIncorrectAddress() {
+        val keypair = Keys.createEcKeyPair()
+
+        // generate proof with wrong address
+        val address = "0000000000000000000000000000000000000000"
+        val esig = keypair.sign(Hash.sha3(address.toByteArray()))
+        val proof =
+            EthereumRegistrationProof(esig, keypair.publicKey)
+
+        assertFalse { checkRegistrationProof(proof) }
+    }
+
+    /**
+     * @given malformed EC keypair and signature
+     * @when check signature
+     * @then check throws IllegalArgumentException
+     */
+    @Test
+    fun testIncorrectSignature() {
+        val keypair = Keys.createEcKeyPair()
+        val proof = EthereumRegistrationProof(
+            ECDSASignature(
+                BigInteger.ZERO,
+                BigInteger.ZERO
+            ), keypair.publicKey
+        )
+
+        assertThrows<IllegalArgumentException> {
+            checkRegistrationProof(
+                proof
+            )
+        }
+    }
+}

--- a/eth-relay/src/main/kotlin/com/d3/eth/registration/relay/RelayRegistration.kt
+++ b/eth-relay/src/main/kotlin/com/d3/eth/registration/relay/RelayRegistration.kt
@@ -49,7 +49,7 @@ class RelayRegistration(
     /** Iroha endpoint */
     private val irohaConsumer = IrohaConsumerImpl(relayCredential, irohaAPI)
 
-    private val notaryIrohaAccount = relayRegistrationConfig.notaryIrohaAccount
+    private val relayStorageAccount = relayRegistrationConfig.relayStorageAccount
 
     /**
      * Registers relay in Iroha.
@@ -57,7 +57,7 @@ class RelayRegistration(
      * @return Result with string representation of hash or possible failure
      */
     fun registerRelayIroha(relayAddress: String): Result<String, Exception> {
-        return ModelUtil.setAccountDetail(irohaConsumer, notaryIrohaAccount, relayAddress, "free")
+        return ModelUtil.setAccountDetail(irohaConsumer, relayStorageAccount, relayAddress, "free")
     }
 
     /**

--- a/eth-relay/src/main/kotlin/com/d3/eth/registration/relay/RelayRegistrationConfig.kt
+++ b/eth-relay/src/main/kotlin/com/d3/eth/registration/relay/RelayRegistrationConfig.kt
@@ -27,7 +27,7 @@ interface RelayRegistrationConfig {
     val ethRelayImplementationAddress: String
 
     /** Notary Iroha account that stores relay register */
-    val notaryIrohaAccount: String
+    val relayStorageAccount: String
 
     val relayRegistrationCredential: IrohaCredentialRawConfig
 

--- a/eth-relay/src/main/kotlin/com/d3/eth/registration/relay/main.kt
+++ b/eth-relay/src/main/kotlin/com/d3/eth/registration/relay/main.kt
@@ -60,7 +60,7 @@ fun main(args: Array<String>) {
 
                 val freeRelayProvider = EthFreeRelayProvider(
                     queryHelper,
-                    relayRegistrationConfig.notaryIrohaAccount,
+                    relayRegistrationConfig.relayStorageAccount,
                     relayRegistrationConfig.relayRegistrationCredential.accountId
                 )
 

--- a/eth-relay/src/main/resources/relay_registration_local.properties
+++ b/eth-relay/src/main/resources/relay_registration_local.properties
@@ -4,7 +4,7 @@ relay-registration.number=5
 # how often run registration of new relays in seconds
 relay-registration.replenishmentPeriod=3600
 # Account to store registered free wallets
-relay-registration.notaryIrohaAccount=notary@notary
+relay-registration.relayStorageAccount=ethereum_relays@notary
 # Master smart contract address
 relay-registration.ethMasterAddress=0xffc8470fd4a88754a97d645320c16e8a2d611a00
 # Address of implementation of Relay contract in Ethereum

--- a/eth-relay/src/main/resources/relay_registration_mainnet.properties
+++ b/eth-relay/src/main/resources/relay_registration_mainnet.properties
@@ -4,7 +4,7 @@ relay-registration.number=1
 # how often run registration of new relays in seconds
 relay-registration.replenishmentPeriod=3600
 # Account to store registered free wallets
-relay-registration.notaryIrohaAccount=notary@notary
+relay-registration.relayStorageAccount=ethereum_relays@notary
 # Master smart contract address
 relay-registration.ethMasterAddress=0x164fe081694ccf1963060f3d1ae34ced15629416
 # Address of implementation of Relay contract in Ethereum

--- a/eth-relay/src/main/resources/relay_registration_testnet.properties
+++ b/eth-relay/src/main/resources/relay_registration_testnet.properties
@@ -4,7 +4,7 @@ relay-registration.number=10
 # how often run registration of new relays in seconds
 relay-registration.replenishmentPeriod=3600
 # Account to store registered free wallets
-relay-registration.notaryIrohaAccount=notary@notary
+relay-registration.relayStorageAccount=ethereum_relays@notary
 # Master smart contract address
 relay-registration.ethMasterAddress=0x7b86bc1d1a1cd949a91e622b2e6c125498f56d6d
 # Address of implementation of Relay contract in Ethereum

--- a/eth-relay/src/test/kotlin/com/d3/eth/registration/relay/RelayRegistrationConfigTest.kt
+++ b/eth-relay/src/test/kotlin/com/d3/eth/registration/relay/RelayRegistrationConfigTest.kt
@@ -54,8 +54,8 @@ class RelayRegistrationConfigTest {
             "RELAY-REGISTRATION_ETHRELAYIMPLEMENTATIONADDRESS",
             ethRelayImplementationAddress
         )
-        val notaryIrohaAccount = "notary@account"
-        environmentVariables.set("RELAY-REGISTRATION_NOTARYIROHAACCOUNT", notaryIrohaAccount)
+        val relayStorageAccount = "ethereum_relays@account"
+        environmentVariables.set("RELAY-REGISTRATION_RELAYSTORAGEACCOUNT", relayStorageAccount)
 
         val relayRegistrationCredentialAccountId = "notary_credentials@account"
         environmentVariables.set(
@@ -100,7 +100,7 @@ class RelayRegistrationConfigTest {
         assertEquals(replenishmentPeriod.toLong(), relayConfig.replenishmentPeriod)
         assertEquals(ethMasterAddress, relayConfig.ethMasterAddress)
         assertEquals(ethRelayImplementationAddress, relayConfig.ethRelayImplementationAddress)
-        assertEquals(notaryIrohaAccount, relayConfig.notaryIrohaAccount)
+        assertEquals(relayStorageAccount, relayConfig.relayStorageAccount)
         assertEquals(
             relayRegistrationCredentialAccountId,
             relayConfig.relayRegistrationCredential.accountId

--- a/eth-vacuum/src/main/kotlin/com/d3/eth/vacuum/RelayVacuum.kt
+++ b/eth-vacuum/src/main/kotlin/com/d3/eth/vacuum/RelayVacuum.kt
@@ -6,7 +6,8 @@
 package com.d3.eth.vacuum
 
 import com.d3.commons.sidechain.iroha.util.IrohaQueryHelper
-import com.d3.eth.provider.EthRelayProviderIrohaImpl
+import com.d3.eth.provider.ETH_RELAY
+import com.d3.eth.provider.EthAddressProviderIrohaImpl
 import com.d3.eth.provider.EthTokensProviderImpl
 import com.d3.eth.sidechain.util.DeployHelper
 import com.github.kittinunf.result.Result
@@ -38,17 +39,18 @@ class RelayVacuum(
         relayVacuumConfig.irohaAnchoredTokenSetterAccount
     )
 
-    private val ethRelayProvider = EthRelayProviderIrohaImpl(
+    private val ethRelayProvider = EthAddressProviderIrohaImpl(
         queryHelper,
         relayVacuumConfig.notaryIrohaAccount,
-        relayVacuumConfig.registrationServiceIrohaAccount
+        relayVacuumConfig.registrationServiceIrohaAccount,
+        ETH_RELAY
     )
 
     /**
      * Returns all non free relays
      */
     private fun getAllRelays(): Result<List<Relay>, Exception> {
-        return ethRelayProvider.getRelays().map { wallets ->
+        return ethRelayProvider.getAddresses().map { wallets ->
             wallets.keys.map { ethPublicKey ->
                 deployHelper.loadRelayContract(ethPublicKey)
             }

--- a/eth-vacuum/src/main/kotlin/com/d3/eth/vacuum/RelayVacuum.kt
+++ b/eth-vacuum/src/main/kotlin/com/d3/eth/vacuum/RelayVacuum.kt
@@ -41,7 +41,7 @@ class RelayVacuum(
 
     private val ethRelayProvider = EthAddressProviderIrohaImpl(
         queryHelper,
-        relayVacuumConfig.notaryIrohaAccount,
+        relayVacuumConfig.relayStorageAccount,
         relayVacuumConfig.registrationServiceIrohaAccount,
         ETH_RELAY
     )

--- a/eth-vacuum/src/main/kotlin/com/d3/eth/vacuum/RelayVacuumConfig.kt
+++ b/eth-vacuum/src/main/kotlin/com/d3/eth/vacuum/RelayVacuumConfig.kt
@@ -27,7 +27,7 @@ interface RelayVacuumConfig {
     val irohaAnchoredTokenSetterAccount: String
 
     /** Notary Iroha account that stores relay register */
-    val notaryIrohaAccount: String
+    val relayStorageAccount: String
 
     /** Iroha configurations */
     val iroha: IrohaConfig

--- a/eth-vacuum/src/main/resources/vacuum_local.properties
+++ b/eth-vacuum/src/main/resources/vacuum_local.properties
@@ -5,7 +5,7 @@ relay-vacuum.ethAnchoredTokenSetterAccount=eth_token_service@notary
 relay-vacuum.irohaAnchoredTokenStorageAccount=iroha_anchored_token_service@notary
 relay-vacuum.irohaAnchoredTokenSetterAccount=eth_token_service@notary
 # Account to store registered free wallets
-relay-vacuum.notaryIrohaAccount=notary@notary
+relay-vacuum.relayStorageAccount=notary@notary
 # --------- Credentials ------
 relay-vacuum.vacuumCredential.accountId=vacuumer@notary
 relay-vacuum.vacuumCredential.pubkey=614faa8c58be90a6bc06d104164d099270e243d18bce02a55f6dd25732887876

--- a/eth-vacuum/src/main/resources/vacuum_mainnet.properties
+++ b/eth-vacuum/src/main/resources/vacuum_mainnet.properties
@@ -5,7 +5,7 @@ relay-vacuum.ethAnchoredTokenSetterAccount=eth_token_service@notary
 relay-vacuum.irohaAnchoredTokenStorageAccount=iroha_anchored_token_service@notary
 relay-vacuum.irohaAnchoredTokenSetterAccount=eth_token_service@notary
 # Account to store registered free wallets
-relay-vacuum.notaryIrohaAccount=notary@notary
+relay-vacuum.relayStorageAccount=notary@notary
 # --------- Credentials ------
 relay-vacuum.vacuumCredential.accountId=vacuumer@notary
 relay-vacuum.vacuumCredential.pubkey=614faa8c58be90a6bc06d104164d099270e243d18bce02a55f6dd25732887876

--- a/eth-vacuum/src/main/resources/vacuum_testnet.properties
+++ b/eth-vacuum/src/main/resources/vacuum_testnet.properties
@@ -5,7 +5,7 @@ relay-vacuum.ethAnchoredTokenSetterAccount=eth_token_service@notary
 relay-vacuum.irohaAnchoredTokenStorageAccount=iroha_anchored_token_service@notary
 relay-vacuum.irohaAnchoredTokenSetterAccount=eth_token_service@notary
 # Account to store registered free wallets
-relay-vacuum.notaryIrohaAccount=notary@notary
+relay-vacuum.relayStorageAccount=ethereum_relays@notary
 # --------- Credentials ------
 relay-vacuum.vacuumCredential.accountId=vacuumer@notary
 relay-vacuum.vacuumCredential.pubkey=614faa8c58be90a6bc06d104164d099270e243d18bce02a55f6dd25732887876

--- a/eth-vacuum/src/test/kotlin/com/d3/eth/vacuum/RelayVacuumTest.kt
+++ b/eth-vacuum/src/test/kotlin/com/d3/eth/vacuum/RelayVacuumTest.kt
@@ -68,8 +68,8 @@ class RelayVacuumTest {
             "RELAY-VACUUM_IROHAANCHOREDTOKENSETTERACCOUNT",
             irohaAnchoredTokenSetterAccount
         )
-        val notaryIrohaAccount = "notary@account"
-        environmentVariables.set("RELAY-VACUUM_NOTARYIROHAACCOUNT", notaryIrohaAccount)
+        val relayStorageAccount = "notary@account"
+        environmentVariables.set("RELAY-VACUUM_RELAYSTORAGEACCOUNT", relayStorageAccount)
         val irohaHostname = "iroha.host"
         environmentVariables.set("RELAY-VACUUM_IROHA_HOSTNAME", irohaHostname)
         val irohaPort = "4040"
@@ -107,7 +107,7 @@ class RelayVacuumTest {
         assertEquals(ethAnchoredTokenSetterAccount, relayConfig.ethAnchoredTokenSetterAccount)
         assertEquals(irohaAnchoredTokenStorageAccount, relayConfig.irohaAnchoredTokenStorageAccount)
         assertEquals(irohaAnchoredTokenSetterAccount, relayConfig.irohaAnchoredTokenSetterAccount)
-        assertEquals(notaryIrohaAccount, relayConfig.notaryIrohaAccount)
+        assertEquals(relayStorageAccount, relayConfig.relayStorageAccount)
         assertEquals(irohaHostname, relayConfig.iroha.hostname)
         assertEquals(irohaPort.toInt(), relayConfig.iroha.port)
         assertEquals(ethereumUrl, relayConfig.ethereum.url)

--- a/eth-withdrawal/src/main/kotlin/com/d3/eth/withdrawal/withdrawalservice/ProofCollector.kt
+++ b/eth-withdrawal/src/main/kotlin/com/d3/eth/withdrawal/withdrawalservice/ProofCollector.kt
@@ -65,7 +65,7 @@ class ProofCollector(
     private val tokensProvider: EthTokensProvider,
     private val notaryPeerListProvider: NotaryPeerListProvider
 ) {
-    private val masterAccount = withdrawalServiceConfig.notaryIrohaAccount
+    private val relayStorageAccount = withdrawalServiceConfig.relayStorageAccount
 
     /**
      * Gather proof from notaries for add peer
@@ -138,7 +138,7 @@ class ProofCollector(
         // description field holds target account address
         return tokensProvider.getTokenAddress(event.asset)
             .fanout { tokensProvider.getTokenPrecision(event.asset) }
-            .fanout { findInAccDetail(masterAccount, event.srcAccount) }
+            .fanout { findInAccDetail(relayStorageAccount, event.srcAccount) }
             .map { (tokenInfo, relayAddress) ->
                 val hash = event.hash
                 val amount = event.amount

--- a/eth-withdrawal/src/main/kotlin/com/d3/eth/withdrawal/withdrawalservice/WithdrawalServiceConfig.kt
+++ b/eth-withdrawal/src/main/kotlin/com/d3/eth/withdrawal/withdrawalservice/WithdrawalServiceConfig.kt
@@ -15,7 +15,7 @@ interface WithdrawalServiceConfig {
     val port: Int
 
     /** Notary account in Iroha */
-    val notaryIrohaAccount: String
+    val relayStorageAccount: String
 
     /** Iroha account that stores Ethereum anchored ERC20 tokens */
     val ethAnchoredTokenStorageAccount: String

--- a/eth-withdrawal/src/main/resources/withdrawal_local.properties
+++ b/eth-withdrawal/src/main/resources/withdrawal_local.properties
@@ -1,7 +1,7 @@
 # ========= Withdrawal ==========
 # port of withdrawal endpoint
 withdrawal.port=8084
-withdrawal.notaryIrohaAccount=notary@notary
+withdrawal.relayStorageAccount=ethereum_relays@notary
 withdrawal.notaryListStorageAccount=notaries@notary
 withdrawal.notaryListSetterAccount=notary@notary
 withdrawal.registrationIrohaAccount=eth_registration_service@notary

--- a/eth-withdrawal/src/main/resources/withdrawal_mainnet.properties
+++ b/eth-withdrawal/src/main/resources/withdrawal_mainnet.properties
@@ -1,7 +1,7 @@
 # ========= Withdrawal ==========
 # port of withdrawal endpoint
 withdrawal.port=8084
-withdrawal.notaryIrohaAccount=notary@notary
+withdrawal.relayStorageAccount=ethereum_relays@notary
 withdrawal.notaryListStorageAccount=notaries@notary
 withdrawal.notaryListSetterAccount=notary@notary
 withdrawal.registrationIrohaAccount=eth_registration_service@notary

--- a/eth-withdrawal/src/main/resources/withdrawal_testnet.properties
+++ b/eth-withdrawal/src/main/resources/withdrawal_testnet.properties
@@ -1,7 +1,7 @@
 # ========= Withdrawal ==========
 # port of withdrawal endpoint
 withdrawal.port=8084
-withdrawal.notaryIrohaAccount=notary@notary
+withdrawal.relayStorageAccount=ethereum_relays@notary
 withdrawal.notaryListStorageAccount=notaries@notary
 withdrawal.notaryListSetterAccount=notary@notary
 withdrawal.registrationIrohaAccount=eth_registration_service@notary

--- a/eth-withdrawal/src/test/kotlin/com/d3/eth/withdrawalservice/WithdrawalServiceConfigTest.kt
+++ b/eth-withdrawal/src/test/kotlin/com/d3/eth/withdrawalservice/WithdrawalServiceConfigTest.kt
@@ -47,8 +47,8 @@ class WithdrawalServiceConfigTest {
     fun allEnvironmentVariablesTest() {
         val port = "133700"
         environmentVariables.set("WITHDRAWAL_PORT", port)
-        val notaryIrohaAccount = "notary@account"
-        environmentVariables.set("WITHDRAWAL_NOTARYIROHAACCOUNT", notaryIrohaAccount)
+        val relayStorageAccount = "ethereum_relays@account"
+        environmentVariables.set("WITHDRAWAL_RELAYSTORAGEACCOUNT", relayStorageAccount)
         val ethAnchoredTokenStorageAccount = "eth_anchored@storage"
         environmentVariables.set(
             "WITHDRAWAL_ETHANCHOREDTOKENSTORAGEACCOUNT",
@@ -129,7 +129,7 @@ class WithdrawalServiceConfigTest {
         ).get()
 
         assertEquals(port.toInt(), withdrawalConfig.port)
-        assertEquals(notaryIrohaAccount, withdrawalConfig.notaryIrohaAccount)
+        assertEquals(relayStorageAccount, withdrawalConfig.relayStorageAccount)
 
         assertEquals(
             ethAnchoredTokenStorageAccount,

--- a/eth/src/main/kotlin/com/d3/eth/provider/EthAddressProvider.kt
+++ b/eth/src/main/kotlin/com/d3/eth/provider/EthAddressProvider.kt
@@ -9,14 +9,14 @@ import com.github.kittinunf.result.Result
 import java.util.*
 
 /** Interface of an instance that provides deployed ethereum relays */
-interface EthRelayProvider {
+interface EthAddressProvider {
 
     /** Returns relays in form of (ethereum wallet -> iroha user name) */
-    fun getRelays(): Result<Map<String, String>, Exception>
+    fun getAddresses(): Result<Map<String, String>, Exception>
 
     /**
      * Get relay belonging to [irohaAccountId]
      * @return relay or null if relay is absent
      */
-    fun getRelayByAccountId(irohaAccountId: String): Result<Optional<String>, Exception>
+    fun getAddressByAccountId(irohaAccountId: String): Result<Optional<String>, Exception>
 }

--- a/eth/src/main/kotlin/com/d3/eth/provider/EthAddressProviderIrohaImpl.kt
+++ b/eth/src/main/kotlin/com/d3/eth/provider/EthAddressProviderIrohaImpl.kt
@@ -12,23 +12,25 @@ import jp.co.soramitsu.iroha.java.ErrorResponseException
 import mu.KLogging
 import java.util.*
 
+const val ETH_RELAY = "ethereum_relay"
 const val ETH_WALLET = "ethereum_wallet"
 
 /**
- * Implementation of [EthRelayProvider] with Iroha storage.
+ * Implementation of [EthAddressProvider] with Iroha storage.
  *
  * @param queryHelper - Iroha queries network layer
  * @param notaryAccount - account that contains details
  * @param registrationAccount - account that has set details
  */
-class EthRelayProviderIrohaImpl(
+class EthAddressProviderIrohaImpl(
     private val queryHelper: IrohaQueryHelper,
-    private val notaryAccount: String,
-    private val registrationAccount: String
-) : EthRelayProvider {
+    private val storageAccountId: String,
+    private val setterAccountId: String,
+    private val key: String
+) : EthAddressProvider {
     init {
         logger.info {
-            "Init relay provider with notary account '$notaryAccount' and registration account '$registrationAccount'"
+            "Init relay provider with storage account '$storageAccountId' and setter account '$setterAccountId'"
         }
     }
 
@@ -39,20 +41,20 @@ class EthRelayProviderIrohaImpl(
      *
      * @return map<eth_wallet -> iroha_account> in success case or exception otherwise
      */
-    override fun getRelays(): Result<Map<String, String>, Exception> {
+    override fun getAddresses(): Result<Map<String, String>, Exception> {
         return queryHelper.getAccountDetailsFilter(
-            notaryAccount,
-            registrationAccount,
+            storageAccountId,
+            setterAccountId,
             nonFreeRelayPredicate
         )
     }
 
     /** Get relay belonging to [irohaAccountId] */
-    override fun getRelayByAccountId(irohaAccountId: String): Result<Optional<String>, Exception> = Result.of {
+    override fun getAddressByAccountId(irohaAccountId: String): Result<Optional<String>, Exception> = Result.of {
         queryHelper.getAccountDetails(
             irohaAccountId,
-            registrationAccount,
-            ETH_WALLET
+            setterAccountId,
+            key
         ).fold(
             { relay ->
                 if (!relay.isPresent) {

--- a/eth/src/main/kotlin/com/d3/eth/provider/EthFreeRelayProvider.kt
+++ b/eth/src/main/kotlin/com/d3/eth/provider/EthFreeRelayProvider.kt
@@ -13,21 +13,21 @@ import mu.KLogging
 /**
  * Provides with free ethereum relay wallet
  * @param queryHelper - iroha queries network layer
- * @param notaryIrohaAccount - Master notary account in Iroha to write down the information about free relay wallets has been added
+ * @param storageAccount - account in Iroha to write down the information about free relay wallets has been added
  */
 // TODO Prevent double relay accounts usage (in perfect world it is on Iroha side with custom code). In real world
 // on provider side with some synchronization.
 class EthFreeRelayProvider(
     private val queryHelper: IrohaQueryHelper,
-    private val notaryIrohaAccount: String,
-    private val registrationIrohaAccount: String
+    private val storageAccount: String,
+    private val setterAccount: String
 ) {
 
     private val freeRelayPredicate = { _: String, value: String -> value == "free" }
 
     init {
         logger.info {
-            "Init free relay provider with holder account '$notaryIrohaAccount' and setter account '$registrationIrohaAccount'"
+            "Init free relay provider with holder account '$storageAccount' and setter account '$setterAccount'"
         }
     }
 
@@ -37,12 +37,12 @@ class EthFreeRelayProvider(
      */
     fun getRelay(): Result<String, Exception> {
         return queryHelper.getAccountDetailsFirst(
-            notaryIrohaAccount,
-            registrationIrohaAccount,
+            storageAccount,
+            setterAccount,
             freeRelayPredicate
         ).map { freeWallet ->
             if (!freeWallet.isPresent)
-                throw IllegalStateException("EthFreeRelayProvider - no free relay wallets created by $registrationIrohaAccount")
+                throw IllegalStateException("EthFreeRelayProvider - no free relay wallets created by $setterAccount")
             freeWallet.get().key
         }
     }
@@ -53,8 +53,8 @@ class EthFreeRelayProvider(
      */
     fun getRelays(): Result<Set<String>, Exception> {
         return queryHelper.getAccountDetailsFilter(
-            notaryIrohaAccount,
-            registrationIrohaAccount,
+            storageAccount,
+            setterAccount,
             freeRelayPredicate
         ).map { relays ->
             relays.keys
@@ -67,8 +67,8 @@ class EthFreeRelayProvider(
      */
     fun getRelaysCount(): Result<Int, Exception> {
         return queryHelper.getAccountDetailsCount(
-            notaryIrohaAccount,
-            registrationIrohaAccount,
+            storageAccount,
+            setterAccount,
             freeRelayPredicate
         )
     }

--- a/eth/src/main/kotlin/com/d3/eth/sidechain/EthChainHandler.kt
+++ b/eth/src/main/kotlin/com/d3/eth/sidechain/EthChainHandler.kt
@@ -21,13 +21,13 @@ import java.math.BigInteger
  * Implementation of [ChainHandler] for Ethereum side chain.
  * Extract interesting transactions from Ethereum block.
  * @param web3 - notary.endpoint of Ethereum client
- * @param ethRelayProvider - provider of observable wallets
+ * @param ethAddressProvider - provider of observable wallets
  * @param ethTokensProvider - provider of observable tokens
  */
 class EthChainHandler(
     val web3: Web3j,
     val masterAddres: String,
-    val ethRelayProvider: EthRelayProvider,
+    val ethRelayProvider: EthAddressProvider,
     val ethTokensProvider: EthTokensProvider,
     deployHelper: DeployHelper
 ) :
@@ -185,7 +185,7 @@ class EthChainHandler(
     override fun parseBlock(block: EthBlock): List<SideChainEvent.PrimaryBlockChainEvent> {
         logger.info { "Ethereum chain handler for block ${block.block.number}" }
 
-        return ethRelayProvider.getRelays().fanout {
+        return ethRelayProvider.getAddresses().fanout {
             ethTokensProvider.getEthAnchoredTokens().fanout {
                 ethTokensProvider.getIrohaAnchoredTokens()
             }

--- a/eth/src/main/kotlin/com/d3/eth/sidechain/util/Crypto.kt
+++ b/eth/src/main/kotlin/com/d3/eth/sidechain/util/Crypto.kt
@@ -13,6 +13,7 @@ import java.math.BigInteger
 
 /**
  * Signs user-provided data with predefined account deployed on local Parity node
+ * @param ecKeyPair keypair used to sign
  * @param toSign data to sign
  * @return signed data
  */
@@ -21,9 +22,8 @@ fun signUserData(ecKeyPair: ECKeyPair, toSign: String): String {
     // Message from hex to bytes
     val dat = Numeric.hexStringToByteArray(toSign)
     // Add ethereum signature format
-    val to_sign = ("\u0019Ethereum Signed Message:\n" + (dat.size)).toByteArray()
-    val data_sign = to_sign.plus(dat)
-    val signature = Sign.signMessage(data_sign, ecKeyPair)
+    val to_sign = ("\u0019Ethereum Signed Message:\n" + (dat.size)).toByteArray() + dat
+    val signature = Sign.signMessage(to_sign, ecKeyPair)
     // Combine in the signature
     var res = Numeric.toHexString(signature.r)
     res = res.plus(Numeric.toHexString(signature.s).substring(2))

--- a/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/DepositIntegrationTest.kt
+++ b/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/DepositIntegrationTest.kt
@@ -67,7 +67,6 @@ class DepositIntegrationTest {
             registrationTestEnvironment.registrationConfig.port
         )
         Assertions.assertEquals(200, res.statusCode)
-        // TODO: D3-417 Web3j cannot pass an empty list of addresses to the smart contract.
         return integrationHelper.registerClientInEth(clientIrohaAccount)
     }
 

--- a/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/DepositIntegrationTest.kt
+++ b/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/DepositIntegrationTest.kt
@@ -50,6 +50,7 @@ class DepositIntegrationTest {
         ethRegistrationService = GlobalScope.launch {
             integrationHelper.runEthRegistrationService(integrationHelper.ethRegistrationConfig)
         }
+        Thread.sleep(5_000)
     }
 
     /** Iroha client account */

--- a/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/EthAddressProviderIrohaTest.kt
+++ b/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/EthAddressProviderIrohaTest.kt
@@ -5,7 +5,8 @@
 
 package integration.eth
 
-import com.d3.eth.provider.EthRelayProviderIrohaImpl
+import com.d3.eth.provider.ETH_RELAY
+import com.d3.eth.provider.EthAddressProviderIrohaImpl
 import integration.helper.EthIntegrationHelperUtil
 import integration.helper.IrohaConfigHelper
 import org.junit.jupiter.api.AfterAll
@@ -19,7 +20,7 @@ import java.time.Duration
  * Requires Iroha is running
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class EthRelayProviderIrohaTest {
+class EthAddressProviderIrohaTest {
 
     val integrationHelper = EthIntegrationHelperUtil()
 
@@ -38,7 +39,7 @@ class EthRelayProviderIrohaTest {
 
     /**
      * @given ethereum relay wallets are stored in the system
-     * @when getRelays() is called
+     * @when getAddresses() is called
      * @then not free wallets are returned in a map
      */
     @Test
@@ -60,11 +61,12 @@ class EthRelayProviderIrohaTest {
 
             val valid = entries.filter { it.value != "free" }
 
-            EthRelayProviderIrohaImpl(
+            EthAddressProviderIrohaImpl(
                 integrationHelper.queryHelper,
                 relayStorage,
-                relaySetter
-            ).getRelays()
+                relaySetter,
+                ETH_RELAY
+            ).getAddresses()
                 .fold(
                     { assertEquals(valid, it) },
                     { ex -> fail("cannot get relays", ex) }
@@ -74,18 +76,19 @@ class EthRelayProviderIrohaTest {
 
     /**
      * @given There is no relay accounts registered (we use test accountId as relay holder)
-     * @when getRelays() is called
+     * @when getAddresses() is called
      * @then empty map is returned
      */
     @Test
     fun testEmptyStorage() {
         assertTimeoutPreemptively(timeoutDuration) {
             integrationHelper.nameCurrentThread(this::class.simpleName!!)
-            EthRelayProviderIrohaImpl(
+            EthAddressProviderIrohaImpl(
                 integrationHelper.queryHelper,
                 integrationHelper.testCredential.accountId,
-                relaySetter
-            ).getRelays()
+                relaySetter,
+                ETH_RELAY
+            ).getAddresses()
                 .fold(
                     { assert(it.isEmpty()) },
                     { ex -> fail("result has exception", ex) }
@@ -95,11 +98,12 @@ class EthRelayProviderIrohaTest {
 
     @Test
     fun testGetByAccountNotFound() {
-        val res = EthRelayProviderIrohaImpl(
+        val res = EthAddressProviderIrohaImpl(
             integrationHelper.queryHelper,
             integrationHelper.testCredential.accountId,
-            relaySetter
-        ).getRelayByAccountId("nonexist@domain")
+            relaySetter,
+            ETH_RELAY
+        ).getAddressByAccountId("nonexist@domain")
         assertFalse(res.get().isPresent)
     }
 }

--- a/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/EthFreeRelayProviderTest.kt
+++ b/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/EthFreeRelayProviderTest.kt
@@ -54,18 +54,17 @@ class EthFreeRelayProviderTest {
 
             setAccountDetail(
                 irohaConsumer,
-                integrationHelper.accountHelper.notaryAccount.accountId,
+                integrationHelper.accountHelper.ethereumRelayStorageAccount.accountId,
                 ethFreeWallet,
                 "free"
             )
                 .failure { fail(it) }
 
-            val freeWalletsProvider =
-                EthFreeRelayProvider(
-                    integrationHelper.queryHelper,
-                    integrationHelper.accountHelper.notaryAccount.accountId,
-                    creator
-                )
+            val freeWalletsProvider = EthFreeRelayProvider(
+                integrationHelper.queryHelper,
+                integrationHelper.accountHelper.ethereumRelayStorageAccount.accountId,
+                creator
+            )
             val result = freeWalletsProvider.getRelay()
 
             assertEquals(ethFreeWallet, result.get())
@@ -110,7 +109,7 @@ class EthFreeRelayProviderTest {
             val freeWalletsProvider =
                 EthFreeRelayProvider(
                     integrationHelper.queryHelper,
-                    integrationHelper.accountHelper.notaryAccount.accountId,
+                    integrationHelper.accountHelper.ethereumRelayStorageAccount.accountId,
                     integrationHelper.accountHelper.registrationAccount.accountId
                 )
 

--- a/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/EthRegistrationProofIntegrationTest.kt
+++ b/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/EthRegistrationProofIntegrationTest.kt
@@ -10,7 +10,13 @@ import com.d3.commons.sidechain.iroha.consumer.IrohaConsumerImpl
 import com.d3.commons.sidechain.iroha.util.ModelUtil
 import com.d3.commons.util.getRandomString
 import com.d3.commons.util.toHexString
+import com.d3.commons.util.irohaEscape
 import com.d3.eth.deposit.endpoint.EthSignature
+import com.d3.eth.provider.ETH_WALLET
+import com.d3.eth.registration.wallet.ETH_FAILED_REGISTRATION_KEY
+import com.d3.eth.registration.wallet.ETH_REGISTRATION_KEY
+import com.d3.eth.registration.wallet.EthereumRegistrationProof
+import com.d3.eth.registration.wallet.createRegistrationProof
 import com.d3.eth.sidechain.util.DeployHelper
 import com.d3.eth.sidechain.util.extractVRS
 import com.d3.eth.sidechain.util.hashToRegistration
@@ -23,10 +29,12 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import org.junit.Assert.assertEquals
 import org.junit.jupiter.api.*
+import org.web3j.crypto.Keys
 import org.web3j.utils.Numeric
 import java.math.BigInteger
 import java.time.Duration
 import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class EthRegistrationProofIntegrationTest {
@@ -58,6 +66,167 @@ class EthRegistrationProofIntegrationTest {
     fun dropDown() {
         ethDeposit.cancel()
         integrationHelper.close()
+    }
+
+    /**
+     * Check whether ethereum wallet was registered for client
+     * @param clientId - iroha account id
+     * @param ethereumAddress - ethereum address as "0x123..."
+     */
+    private fun checkRegisteredEthereumAddress(clientId: String, ethereumAddress: String) {
+        val registeredAddress = integrationHelper.queryHelper.getAccountDetails(
+            clientId,
+            integrationHelper.accountHelper.notaryAccount.accountId,
+            ETH_WALLET
+        ).get().get()
+        assertEquals(ethereumAddress, registeredAddress)
+
+        val registeredAccount = integrationHelper.queryHelper.getAccountDetails(
+            integrationHelper.accountHelper.ethereumWalletStorageAccount.accountId,
+            integrationHelper.accountHelper.notaryAccount.accountId,
+            ethereumAddress
+        ).get().get()
+        assertEquals(clientId, registeredAccount)
+    }
+
+    /**
+     * @given notary service is running and client with iroha account and ethereum wallet
+     * @when the client sends ethereum wallet registration request
+     * @then ethereum address is registered for client
+     */
+    @Test
+    fun correctWalletRegistration() {
+        Assertions.assertTimeoutPreemptively(timeoutDuration) {
+            val keyPair = ModelUtil.generateKeypair()
+            val clientIrohaAccount = String.getRandomString(5)
+            val ethKeypair = Keys.createEcKeyPair()
+            val clientId = "$clientIrohaAccount@d3"
+            val ethereumAddress = "0x${Keys.getAddress(ethKeypair.publicKey)}"
+
+            // register iroha account
+            val res = integrationHelper.sendRegistrationRequest(
+                clientIrohaAccount,
+                keyPair.public.toHexString(),
+                registrationTestEnvironment.registrationConfig.port
+            )
+            assertEquals(200, res.statusCode)
+
+            // register in Ethereum
+            integrationHelper.registerEthereumWallet(clientId, keyPair, ethKeypair)
+
+            Thread.sleep(3_000)
+            checkRegisteredEthereumAddress(clientId, ethereumAddress)
+        }
+    }
+
+    /**
+     * @given notary service is running and client with iroha account and ethereum wallet
+     * @when the client sends ethereum wallet registration request with wrong proof
+     * @then failed registration record is sent to iroha,
+     */
+    @Test
+    fun correctAfterIncorrectWalletRegistration() {
+        Assertions.assertTimeoutPreemptively(timeoutDuration) {
+            val keyPair = ModelUtil.generateKeypair()
+            val clientIrohaAccount = String.getRandomString(5)
+            val ethKeypair = Keys.createEcKeyPair()
+            val clientId = "$clientIrohaAccount@d3"
+            val ethereumAddress = "0x${Keys.getAddress(ethKeypair.publicKey)}"
+
+            // register iroha account
+            val res = integrationHelper.sendRegistrationRequest(
+                clientIrohaAccount,
+                keyPair.public.toHexString(),
+                registrationTestEnvironment.registrationConfig.port
+            )
+            assertEquals(200, res.statusCode)
+
+            // send wrong signature
+            val clientIrohaConsumer = IrohaConsumerImpl(
+                IrohaCredential(clientId, keyPair),
+                integrationHelper.irohaAPI
+            )
+            val signature = createRegistrationProof(ethKeypair)
+            val wrongSignature = EthereumRegistrationProof(signature.signature, BigInteger.ZERO)
+            integrationHelper.setAccountDetail(
+                clientIrohaConsumer,
+                integrationHelper.accountHelper.registrationAccount.accountId,
+                ETH_REGISTRATION_KEY,
+                wrongSignature.toJson().irohaEscape(),
+                quorum = 2
+            )
+            Thread.sleep(3_000)
+
+            // check wrong registration
+            assertTrue {
+                integrationHelper.queryHelper.getAccountDetails(
+                    clientId,
+                    integrationHelper.accountHelper.notaryAccount.accountId,
+                    ETH_FAILED_REGISTRATION_KEY
+                ).get().isPresent
+            }
+
+            // register in Ethereum again
+            integrationHelper.registerEthereumWallet(clientId, keyPair, ethKeypair)
+
+            Thread.sleep(3_000)
+            checkRegisteredEthereumAddress(clientId, ethereumAddress)
+        }
+    }
+
+    /**
+     * @given
+     * @when
+     * @then
+     */
+    @Test
+    fun doubleWalletRegistration() {
+        Assertions.assertTimeoutPreemptively(timeoutDuration) {
+            val ethKeypair = Keys.createEcKeyPair()
+            val ethereumAddress = "0x${Keys.getAddress(ethKeypair.publicKey)}"
+
+            val keyPair1 = ModelUtil.generateKeypair()
+            val clientIrohaAccount1 = String.getRandomString(5)
+            val clientId1 = "$clientIrohaAccount1@d3"
+
+            val keyPair2 = ModelUtil.generateKeypair()
+            val clientIrohaAccount2 = String.getRandomString(5)
+            val clientId2 = "$clientIrohaAccount2@d3"
+
+            // register iroha accounts
+            val res1 = integrationHelper.sendRegistrationRequest(
+                clientIrohaAccount1,
+                keyPair1.public.toHexString(),
+                registrationTestEnvironment.registrationConfig.port
+            )
+            assertEquals(200, res1.statusCode)
+
+            val res2 = integrationHelper.sendRegistrationRequest(
+                clientIrohaAccount2,
+                keyPair2.public.toHexString(),
+                registrationTestEnvironment.registrationConfig.port
+            )
+            assertEquals(200, res2.statusCode)
+
+            // register in Ethereum client1
+            integrationHelper.registerEthereumWallet(clientId1, keyPair1, ethKeypair)
+            Thread.sleep(3_000)
+
+            checkRegisteredEthereumAddress(clientId1, ethereumAddress)
+
+            // register in Ethereum client2 with the same Ethereum address
+            integrationHelper.registerEthereumWallet(clientId2, keyPair2, ethKeypair)
+            Thread.sleep(3_000)
+
+            // check wrong registration
+            assertTrue {
+                integrationHelper.queryHelper.getAccountDetails(
+                    clientId2,
+                    integrationHelper.accountHelper.notaryAccount.accountId,
+                    ETH_FAILED_REGISTRATION_KEY
+                ).get().isPresent
+            }
+        }
     }
 
     /**

--- a/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/WithdrawalIntegrationTest.kt
+++ b/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/WithdrawalIntegrationTest.kt
@@ -12,7 +12,8 @@ import com.d3.eth.deposit.endpoint.BigIntegerMoshiAdapter
 import com.d3.eth.deposit.endpoint.EthNotaryResponse
 import com.d3.eth.deposit.endpoint.EthNotaryResponseMoshiAdapter
 import com.d3.eth.provider.ETH_PRECISION
-import com.d3.eth.provider.EthRelayProviderIrohaImpl
+import com.d3.eth.provider.ETH_RELAY
+import com.d3.eth.provider.EthAddressProviderIrohaImpl
 import com.d3.eth.sidechain.util.DeployHelper
 import com.d3.eth.sidechain.util.ENDPOINT_ETHEREUM
 import com.d3.eth.sidechain.util.hashToWithdraw
@@ -109,11 +110,12 @@ class WithdrawalIntegrationTest {
                 integrationHelper.testCredential.keyPair
             )
             integrationHelper.addIrohaAssetTo(clientId, assetId, decimalAmount)
-            val relay = EthRelayProviderIrohaImpl(
+            val relay = EthAddressProviderIrohaImpl(
                 integrationHelper.queryHelper,
                 masterAccount,
-                integrationHelper.accountHelper.registrationAccount.accountId
-            ).getRelays().get().filter {
+                integrationHelper.accountHelper.registrationAccount.accountId,
+                ETH_RELAY
+            ).getAddresses().get().filter {
                 it.value == clientId
             }.keys.first()
 

--- a/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/WithdrawalIntegrationTest.kt
+++ b/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/WithdrawalIntegrationTest.kt
@@ -88,7 +88,6 @@ class WithdrawalIntegrationTest {
     fun testRefund() {
         assertTimeoutPreemptively(timeoutDuration) {
             integrationHelper.nameCurrentThread(this::class.simpleName!!)
-            val masterAccount = depositConfig.notaryCredential.accountId
             val withdrawalAccountId = depositConfig.withdrawalAccountId
             val amount = "64203"
             val decimalAmount = BigDecimal(amount).scaleByPowerOfTen(ETH_PRECISION)
@@ -112,7 +111,7 @@ class WithdrawalIntegrationTest {
             integrationHelper.addIrohaAssetTo(clientId, assetId, decimalAmount)
             val relay = EthAddressProviderIrohaImpl(
                 integrationHelper.queryHelper,
-                masterAccount,
+                integrationHelper.accountHelper.ethereumRelayStorageAccount.accountId,
                 integrationHelper.accountHelper.registrationAccount.accountId,
                 ETH_RELAY
             ).getAddresses().get().filter {

--- a/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/WithdrawalMultinotaryIntegrationTest.kt
+++ b/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/WithdrawalMultinotaryIntegrationTest.kt
@@ -142,7 +142,6 @@ class WithdrawalMultinotaryIntegrationTest {
     fun testRefundEndpoints() {
         Assertions.assertTimeoutPreemptively(timeoutDuration) {
             integrationHelper.nameCurrentThread(this::class.simpleName!!)
-            val masterAccount = integrationHelper.accountHelper.notaryAccount.accountId
             val amount = "64203"
             val decimalAmount = BigDecimal(amount).scaleByPowerOfTen(ETH_PRECISION)
             val assetId = "ether#ethereum"
@@ -165,7 +164,7 @@ class WithdrawalMultinotaryIntegrationTest {
             integrationHelper.addIrohaAssetTo(clientId, assetId, decimalAmount)
             val relay = EthAddressProviderIrohaImpl(
                 integrationHelper.queryHelper,
-                masterAccount,
+                integrationHelper.accountHelper.ethereumRelayStorageAccount.accountId,
                 integrationHelper.accountHelper.registrationAccount.accountId,
                 ETH_RELAY
             ).getAddresses().get().filter {

--- a/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/WithdrawalMultinotaryIntegrationTest.kt
+++ b/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/WithdrawalMultinotaryIntegrationTest.kt
@@ -13,7 +13,8 @@ import com.d3.eth.deposit.endpoint.BigIntegerMoshiAdapter
 import com.d3.eth.deposit.endpoint.EthNotaryResponse
 import com.d3.eth.deposit.endpoint.EthNotaryResponseMoshiAdapter
 import com.d3.eth.provider.ETH_PRECISION
-import com.d3.eth.provider.EthRelayProviderIrohaImpl
+import com.d3.eth.provider.ETH_RELAY
+import com.d3.eth.provider.EthAddressProviderIrohaImpl
 import com.d3.eth.sidechain.util.DeployHelper
 import com.d3.eth.sidechain.util.ENDPOINT_ETHEREUM
 import com.d3.eth.sidechain.util.hashToWithdraw
@@ -162,11 +163,12 @@ class WithdrawalMultinotaryIntegrationTest {
                 integrationHelper.testCredential.keyPair
             )
             integrationHelper.addIrohaAssetTo(clientId, assetId, decimalAmount)
-            val relay = EthRelayProviderIrohaImpl(
+            val relay = EthAddressProviderIrohaImpl(
                 integrationHelper.queryHelper,
                 masterAccount,
-                integrationHelper.accountHelper.registrationAccount.accountId
-            ).getRelays().get().filter {
+                integrationHelper.accountHelper.registrationAccount.accountId,
+                ETH_RELAY
+            ).getAddresses().get().filter {
                 it.value == clientId
             }.keys.first()
 

--- a/notary-eth-integration-test/src/main/kotlin/integration/helper/EthConfigHelper.kt
+++ b/notary-eth-integration-test/src/main/kotlin/integration/helper/EthConfigHelper.kt
@@ -114,8 +114,6 @@ open class EthConfigHelper(
         )
     ): EthDepositConfig {
         return object : EthDepositConfig {
-            override val registrationServiceIrohaAccount =
-                accountHelper.registrationAccount.accountId
             override val notaryListStorageAccount = accountHelper.notaryListStorageAccount.accountId
             override val expansionTriggerAccount = accountHelper.expansionTriggerAccount.accountId
             override val expansionTriggerCreatorAccountId = accountHelper.superuserAccount.accountId
@@ -136,6 +134,10 @@ open class EthConfigHelper(
             override val withdrawalAccountId = accountHelper.withdrawalAccount.accountId
             override val ethIrohaDepositQueue = testName
             override val ethMasterAddress = masterContractAddress
+            override val ethereumWalletStorageAccount = accountHelper.ethereumWalletStorageAccount.accountId
+            override val ethereumWalletSetterAccount = accountHelper.notaryAccount.accountId
+            override val ethereumRelayStorageAccount = accountHelper.ethereumRelayStorageAccount.accountId
+            override val ethereumRelaySetterAccount = accountHelper.registrationAccount.accountId
         }
     }
 

--- a/notary-eth-integration-test/src/main/kotlin/integration/helper/EthConfigHelper.kt
+++ b/notary-eth-integration-test/src/main/kotlin/integration/helper/EthConfigHelper.kt
@@ -81,7 +81,7 @@ open class EthConfigHelper(
             override val replenishmentPeriod = relayRegistrationConfig.replenishmentPeriod
             override val ethMasterAddress = masterContractAddress
             override val ethRelayImplementationAddress = relayImplementaionContractAddress
-            override val notaryIrohaAccount = accountHelper.notaryAccount.accountId
+            override val relayStorageAccount = accountHelper.ethereumRelayStorageAccount.accountId
             override val iroha = createIrohaConfig()
             override val ethereum = relayRegistrationConfig.ethereum
             override val relayRegistrationCredential =
@@ -159,7 +159,7 @@ open class EthConfigHelper(
             )
 
         return object : WithdrawalServiceConfig {
-            override val notaryIrohaAccount = accountHelper.notaryAccount.accountId
+            override val relayStorageAccount = accountHelper.ethereumRelayStorageAccount.accountId
             override val ethAnchoredTokenStorageAccount =
                 accountHelper.ethAnchoredTokenStorageAccount.accountId
             override val ethAnchoredTokenSetterAccount = accountHelper.tokenSetterAccount.accountId
@@ -198,7 +198,7 @@ open class EthConfigHelper(
         return object : EthRegistrationConfig {
             override val port = portCounter.incrementAndGet()
             override val relayRegistrationIrohaAccount = accountHelper.registrationAccount.accountId
-            override val notaryIrohaAccount = accountHelper.notaryAccount.accountId
+            override val relayStorageAccount = accountHelper.ethereumRelayStorageAccount.accountId
             override val iroha = createIrohaConfig()
             override val registrationCredential =
                 accountHelper.createCredentialRawConfig(accountHelper.registrationAccount)
@@ -224,7 +224,7 @@ open class EthConfigHelper(
             override val irohaAnchoredTokenSetterAccount =
                 accountHelper.tokenSetterAccount.accountId
             /** Notary Iroha account that stores relay register */
-            override val notaryIrohaAccount = accountHelper.notaryAccount.accountId
+            override val relayStorageAccount = accountHelper.ethereumRelayStorageAccount.accountId
 
             override val vacuumCredential =
                 accountHelper.createCredentialRawConfig(accountHelper.testCredential)

--- a/notary-eth-integration-test/src/main/kotlin/integration/helper/EthIntegrationHelperUtil.kt
+++ b/notary-eth-integration-test/src/main/kotlin/integration/helper/EthIntegrationHelperUtil.kt
@@ -131,7 +131,7 @@ class EthIntegrationHelperUtil : IrohaIntegrationHelperUtil() {
     private val ethFreeRelayProvider by lazy {
         EthFreeRelayProvider(
             registrationQueryHelper,
-            accountHelper.notaryAccount.accountId,
+            accountHelper.ethereumRelayStorageAccount.accountId,
             accountHelper.registrationAccount.accountId
         )
     }
@@ -140,7 +140,7 @@ class EthIntegrationHelperUtil : IrohaIntegrationHelperUtil() {
     private val ethRelayProvider by lazy {
         EthAddressProviderIrohaImpl(
             registrationQueryHelper,
-            accountHelper.notaryAccount.accountId,
+            accountHelper.ethereumRelayStorageAccount.accountId,
             accountHelper.registrationAccount.accountId,
             ETH_RELAY
         )
@@ -151,7 +151,7 @@ class EthIntegrationHelperUtil : IrohaIntegrationHelperUtil() {
             ethFreeRelayProvider,
             ethRelayProvider,
             registrationConsumer,
-            accountHelper.notaryAccount.accountId
+            accountHelper.ethereumRelayStorageAccount.accountId
         )
     }
 

--- a/notary-eth-integration-test/src/main/kotlin/integration/helper/EthIntegrationHelperUtil.kt
+++ b/notary-eth-integration-test/src/main/kotlin/integration/helper/EthIntegrationHelperUtil.kt
@@ -10,32 +10,36 @@ import com.d3.commons.config.loadConfigs
 import com.d3.commons.config.loadRawLocalConfigs
 import com.d3.commons.expansion.ExpansionDetails
 import com.d3.commons.expansion.ExpansionUtils
+import com.d3.commons.model.IrohaCredential
 import com.d3.commons.sidechain.iroha.consumer.IrohaConsumerImpl
 import com.d3.commons.sidechain.iroha.util.ModelUtil
 import com.d3.commons.sidechain.iroha.util.impl.IrohaQueryHelperImpl
 import com.d3.commons.sidechain.provider.FileBasedLastReadBlockProvider
 import com.d3.commons.util.getRandomString
 import com.d3.commons.util.toHexString
+import com.d3.commons.util.irohaEscape
 import com.d3.eth.constants.ETH_MASTER_ADDRESS_KEY
 import com.d3.eth.constants.ETH_RELAY_REGISTRY_KEY
 import com.d3.eth.deposit.EthDepositConfig
 import com.d3.eth.deposit.executeDeposit
-import com.d3.eth.provider.ETH_DOMAIN
-import com.d3.eth.provider.EthFreeRelayProvider
-import com.d3.eth.provider.EthRelayProviderIrohaImpl
-import com.d3.eth.provider.EthTokensProviderImpl
+import com.d3.eth.provider.*
 import com.d3.eth.registration.EthRegistrationConfig
 import com.d3.eth.registration.EthRegistrationStrategyImpl
 import com.d3.eth.registration.executeRegistration
 import com.d3.eth.registration.relay.RelayRegistration
+import com.d3.eth.registration.wallet.ETH_REGISTRATION_KEY
+import com.d3.eth.registration.wallet.EthereumRegistrationProof
+import com.d3.eth.registration.wallet.createRegistrationProof
 import com.d3.eth.sidechain.EthChainListener
 import com.d3.eth.token.EthTokenInfo
 import com.d3.eth.vacuum.RelayVacuumConfig
 import com.d3.eth.withdrawal.withdrawalservice.WithdrawalServiceConfig
+import com.github.kittinunf.result.Result
 import com.github.kittinunf.result.success
 import integration.eth.config.EthereumPasswords
 import kotlinx.coroutines.runBlocking
 import mu.KLogging
+import org.web3j.crypto.ECKeyPair
 import java.math.BigInteger
 import java.security.KeyPair
 import java.util.*
@@ -134,10 +138,11 @@ class EthIntegrationHelperUtil : IrohaIntegrationHelperUtil() {
 
     /** Provider of ETH wallets created by registrationAccount*/
     private val ethRelayProvider by lazy {
-        EthRelayProviderIrohaImpl(
+        EthAddressProviderIrohaImpl(
             registrationQueryHelper,
             accountHelper.notaryAccount.accountId,
-            accountHelper.registrationAccount.accountId
+            accountHelper.registrationAccount.accountId,
+            ETH_RELAY
         )
     }
 
@@ -173,7 +178,7 @@ class EthIntegrationHelperUtil : IrohaIntegrationHelperUtil() {
      * Get relay address of an account.
      */
     fun getRelayByAccount(clientId: String): Optional<String> {
-        return ethRelayProvider.getRelayByAccountId(clientId).get()
+        return ethRelayProvider.getAddressByAccountId(clientId).get()
     }
 
     /**
@@ -370,7 +375,7 @@ class EthIntegrationHelperUtil : IrohaIntegrationHelperUtil() {
     /**
      * Returns wallets registered by master account in Iroha
      */
-    fun getRegisteredEthWallets(): Set<String> = ethRelayProvider.getRelays().get().keys
+    fun getRegisteredEthWallets(): Set<String> = ethRelayProvider.getAddresses().get().keys
 
     /**
      * Add list of [relays].
@@ -410,6 +415,35 @@ class EthIntegrationHelperUtil : IrohaIntegrationHelperUtil() {
     }
 
     /**
+     * Send transaction from client to trigger Ethereum registration.
+     * The transaction contains ethereum address proof from client.
+     * @param clientId - Iroha client id
+     * @param irohaKeyPair - iroha client keypair
+     * @param ethereumKeyPair - ethereum client keypair
+     * @return result of tx sent with hash
+     */
+    fun registerEthereumWallet(
+        clientId: String,
+        irohaKeyPair: KeyPair,
+        ethereumKeyPair: ECKeyPair
+    ): Result<String, Exception> {
+        // register in Ethereum
+        val clientIrohaConsumer = IrohaConsumerImpl(
+            IrohaCredential(clientId, irohaKeyPair),
+            irohaAPI
+        )
+        val signature = createRegistrationProof(ethereumKeyPair)
+        return setAccountDetail(
+            clientIrohaConsumer,
+            accountHelper.registrationAccount.accountId,
+            ETH_REGISTRATION_KEY,
+            signature.toJson().irohaEscape(),
+            quorum = 2
+        )
+    }
+
+
+    /**
      * Run Ethereum notary process
      */
     fun runEthDeposit(
@@ -420,13 +454,14 @@ class EthIntegrationHelperUtil : IrohaIntegrationHelperUtil() {
         rmqConfig: RMQConfig = loadRawLocalConfigs(
             "rmq",
             RMQConfig::class.java, "rmq.properties"
-        )
+        ),
+        registrationConfig: EthRegistrationConfig = configHelper.createEthRegistrationConfig()
     ) {
         val name = String.getRandomString(9)
         val address = "http://localhost:${ethDepositConfig.refund.port}"
         addNotary(name, address)
 
-        executeDeposit(ethereumPasswords, ethDepositConfig, rmqConfig)
+        executeDeposit(ethereumPasswords, ethDepositConfig, rmqConfig, registrationConfig)
 
         logger.info { "Notary $name is started on $address" }
     }

--- a/notary-eth-integration-test/src/main/kotlin/integration/helper/EthereumAccountHelper.kt
+++ b/notary-eth-integration-test/src/main/kotlin/integration/helper/EthereumAccountHelper.kt
@@ -23,4 +23,11 @@ class EthereumAccountHelper(irohaApi: IrohaAPI) : IrohaAccountHelper(irohaApi) {
 
     /** Account that sets Ethereum addresses */
     val ethAddressesWriter = createTesterAccount("eth_addr_writer", listOf("tester"))
+
+    /** list of registered ethereum wallets */
+    val ethereumWalletStorageAccount = createTesterAccount("ethereum_wallets")
+
+    /** list of registered ethereum relays */
+    val ethereumRelayStorageAccount = createTesterAccount("ethereum_relays")
+
 }

--- a/notary-eth-integration-test/src/main/kotlin/integration/helper/NotaryClient.kt
+++ b/notary-eth-integration-test/src/main/kotlin/integration/helper/NotaryClient.kt
@@ -9,9 +9,13 @@ import com.d3.commons.model.IrohaCredential
 import com.d3.commons.sidechain.iroha.util.ModelUtil
 import com.d3.commons.util.getRandomString
 import com.d3.commons.util.toHexString
+import com.d3.eth.registration.wallet.EthereumRegistrationProof
+import com.d3.eth.registration.wallet.ETH_REGISTRATION_KEY
+import com.d3.eth.registration.wallet.createRegistrationProof
 import com.d3.eth.sidechain.util.DeployHelper
 import integration.eth.config.EthereumConfig
 import integration.eth.config.EthereumPasswords
+import com.d3.commons.util.irohaEscape
 import mu.KLogging
 import java.math.BigInteger
 
@@ -32,6 +36,9 @@ class NotaryClient(
     /** Notary Iroha account id */
     private val notaryAccountId = integrationHelper.accountHelper.notaryAccount.accountId
 
+    /** Ethereum registration service */
+    private val registrationAccountId = integrationHelper.accountHelper.registrationAccount.accountId
+
     /** Client Iroha account id */
     val accountId = irohaCredential.accountId
 
@@ -46,7 +53,7 @@ class NotaryClient(
     }
 
     /**
-     * Send HTTP POST request to registration service to register user
+     * Send HTTP POST request to registration service to register user with Relay
      */
     fun signUp(): khttp.responses.Response {
         val response = integrationHelper.sendRegistrationRequest(
@@ -57,6 +64,19 @@ class NotaryClient(
         relay = response.text
 
         return response
+    }
+
+    /**
+     * Send request to register user with existing Ethereum wallet.
+     */
+    fun signUpWithWallet() {
+        val signature = createRegistrationProof(etherHelper.credentials.ecKeyPair)
+        integrationHelper.setAccountDetail(
+            integrationHelper.irohaConsumer,
+            registrationAccountId,
+            ETH_REGISTRATION_KEY,
+            signature.toJson().irohaEscape()
+        )
     }
 
     fun deposit(amount: BigInteger) {

--- a/notary-eth-integration-test/src/main/kotlin/integration/helper/NotaryClient.kt
+++ b/notary-eth-integration-test/src/main/kotlin/integration/helper/NotaryClient.kt
@@ -9,13 +9,13 @@ import com.d3.commons.model.IrohaCredential
 import com.d3.commons.sidechain.iroha.util.ModelUtil
 import com.d3.commons.util.getRandomString
 import com.d3.commons.util.toHexString
+import com.d3.commons.util.irohaEscape
 import com.d3.eth.registration.wallet.EthereumRegistrationProof
 import com.d3.eth.registration.wallet.ETH_REGISTRATION_KEY
 import com.d3.eth.registration.wallet.createRegistrationProof
 import com.d3.eth.sidechain.util.DeployHelper
 import integration.eth.config.EthereumConfig
 import integration.eth.config.EthereumPasswords
-import com.d3.commons.util.irohaEscape
 import mu.KLogging
 import java.math.BigInteger
 


### PR DESCRIPTION
Wallet Iroha-based registration. Relay providers and wallets provider are separated into different accounts. To register user should put account details with Ethereum proof into registration service account. Notary registers client or commits reject.