### PR TITLE
rewrite eth-registration proof to make JS-compatible

### DIFF
--- a/eth-deposit/src/main/kotlin/com/d3/eth/deposit/WithdrawalProof.kt
+++ b/eth-deposit/src/main/kotlin/com/d3/eth/deposit/WithdrawalProof.kt
@@ -5,7 +5,7 @@
 
 package com.d3.eth.deposit
 
-import java.math.BigInteger
+import com.d3.eth.sidechain.util.VRSSignature
 
 /**
  * Represents Ethereum withdrawal proof from one node
@@ -32,11 +32,3 @@ data class WithdrawalProof(
     // ethereum notary signature
     val signature: VRSSignature
 )
-
-/**
- * Data class which stores signature splitted into components
- * @param v v component of signature
- * @param r r component of signature in hex
- * @param s s component of signature in hex
- */
-data class VRSSignature(val v: BigInteger, val r: String, val s: String)

--- a/eth-deposit/src/main/kotlin/com/d3/eth/deposit/WithdrawalProofHandler.kt
+++ b/eth-deposit/src/main/kotlin/com/d3/eth/deposit/WithdrawalProofHandler.kt
@@ -14,10 +14,7 @@ import com.d3.commons.util.hex
 import com.d3.commons.util.irohaEscape
 import com.d3.eth.provider.EthAddressProvider
 import com.d3.eth.provider.EthTokensProvider
-import com.d3.eth.sidechain.util.DeployHelper
-import com.d3.eth.sidechain.util.extractVRS
-import com.d3.eth.sidechain.util.hashToMint
-import com.d3.eth.sidechain.util.hashToWithdraw
+import com.d3.eth.sidechain.util.*
 import integration.eth.config.EthereumPasswords
 import iroha.protocol.BlockOuterClass
 import jp.co.soramitsu.iroha.java.IrohaAPI
@@ -26,7 +23,6 @@ import mu.KLogging
 import org.apache.commons.codec.binary.Hex
 import org.web3j.crypto.WalletUtils
 import java.math.BigDecimal
-import java.math.BigInteger
 
 const val ETH_WITHDRAWAL_PROOF_DOMAIN = "ethWithdrawalProof"
 const val WITHDRAWAL_ACCOUNT_PUBLIC_KEY =
@@ -156,7 +152,10 @@ class WithdrawalProofHandler(
             )
         val signatureString = deployHelper.signUserData(hash)
         val vrs = extractVRS(signatureString)
-        val signature = VRSSignature(vrs.v, Hex.encodeHexString(vrs.r), Hex.encodeHexString(vrs.s))
+        val v = vrs.v.toString(16).replace("0x", "")
+        val r = Hex.encodeHexString(vrs.r).replace("0x", "")
+        val s = Hex.encodeHexString(vrs.s).replace("0x", "")
+        val signature = VRSSignature(v, r, s)
 
         val withdrawalProof = WithdrawalProof(
             accountId,

--- a/eth-registration/src/main/kotlin/com/d3/eth/registration/wallet/EthereumRegistrationProof.kt
+++ b/eth-registration/src/main/kotlin/com/d3/eth/registration/wallet/EthereumRegistrationProof.kt
@@ -5,6 +5,7 @@
 
 package com.d3.eth.registration.wallet
 
+import com.d3.eth.sidechain.util.VRSSignature
 import com.google.gson.Gson
 import org.web3j.crypto.*
 import java.math.BigInteger
@@ -16,7 +17,7 @@ const val ETH_REGISTRATION_KEY = "register_wallet"
  * EC Signature of an address generated from public key.
  */
 data class EthereumRegistrationProof(
-    val signature: ECDSASignature,
+    val signature: VRSSignature,
     val publicKey: BigInteger
 ) {
     /**

--- a/eth/src/main/kotlin/com/d3/eth/sidechain/util/Crypto.kt
+++ b/eth/src/main/kotlin/com/d3/eth/sidechain/util/Crypto.kt
@@ -113,6 +113,14 @@ fun hashToMint(
 data class VRS(val v: BigInteger, val r: ByteArray, val s: ByteArray)
 
 /**
+ * Data class which stores signature splitted into components
+ * @param v v component of signature
+ * @param r r component of signature in hex
+ * @param s s component of signature in hex
+ */
+data class VRSSignature(val v: String, val r: String, val s: String)
+
+/**
  * Extracts VRS-signature from string-encoded signature
  * @param signature string-encoded signature
  * @return VRS object

--- a/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/EthRegistrationProofIntegrationTest.kt
+++ b/notary-eth-integration-test/src/integration-test/kotlin/integration/eth/EthRegistrationProofIntegrationTest.kt
@@ -11,14 +11,12 @@ import com.d3.commons.sidechain.iroha.util.ModelUtil
 import com.d3.commons.util.getRandomString
 import com.d3.commons.util.toHexString
 import com.d3.commons.util.irohaEscape
-import com.d3.eth.deposit.endpoint.EthSignature
 import com.d3.eth.provider.ETH_WALLET
 import com.d3.eth.registration.wallet.ETH_FAILED_REGISTRATION_KEY
 import com.d3.eth.registration.wallet.ETH_REGISTRATION_KEY
 import com.d3.eth.registration.wallet.EthereumRegistrationProof
 import com.d3.eth.registration.wallet.createRegistrationProof
 import com.d3.eth.sidechain.util.DeployHelper
-import com.d3.eth.sidechain.util.extractVRS
 import integration.helper.ContractTestHelper
 import integration.helper.EthIntegrationHelperUtil
 import integration.helper.IrohaConfigHelper
@@ -29,10 +27,8 @@ import kotlinx.coroutines.launch
 import org.junit.Assert.assertEquals
 import org.junit.jupiter.api.*
 import org.web3j.crypto.Keys
-import org.web3j.utils.Numeric
 import java.math.BigInteger
 import java.time.Duration
-import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)

--- a/notary-eth-integration-test/src/main/kotlin/integration/helper/EthIntegrationHelperUtil.kt
+++ b/notary-eth-integration-test/src/main/kotlin/integration/helper/EthIntegrationHelperUtil.kt
@@ -602,7 +602,7 @@ class EthIntegrationHelperUtil : IrohaIntegrationHelperUtil() {
             .map { (ethNotaryAddress, withdrawalProofJson) ->
                 val withdrawalProof =
                     gson.fromJson(withdrawalProofJson.irohaUnEscape(), WithdrawalProof::class.java)
-                vv.add(withdrawalProof.signature.v)
+                vv.add(BigInteger(withdrawalProof.signature.v, 16))
                 rr.add(Numeric.hexStringToByteArray(withdrawalProof.signature.r))
                 ss.add(Numeric.hexStringToByteArray(withdrawalProof.signature.s))
             }
@@ -637,6 +637,8 @@ class EthIntegrationHelperUtil : IrohaIntegrationHelperUtil() {
         val ethTransaction = contractTestHelper.deployHelper.web3.ethGetTransactionByHash(transactionResponse.transactionHash).send()
         logger.info { "Gas used: ${ethTransaction.transaction.get().gas}" }
         logger.info { "Gas price: ${ethTransaction.transaction.get().gasPrice}" }
+        logger.info { "Tx input hash: ${txHash}" }
+        logger.info { "Tx Input: ${ethTransaction.transaction.get().input}" }
     }
 
     /**


### PR DESCRIPTION
Changed API of registration, now it accepts r and s in hex.
Also signature is changed to Ethereum type with prefix "Ethereum signature:".